### PR TITLE
Fix typo in the word `velocity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pop is an extensible animation engine for iOS and OS X. In addition to basic sta
 
 ## Installation
 
-Pop will soon be available on [CocoaPods](http://cocoapods.org). Once indexed, add the following to your project Podfile:
+Pop will soon be available via CocoaPods. Add the following to your project Podfile:
 
 ```ruby
 pod 'pop'
@@ -61,7 +61,7 @@ POPSpringAnimation *anim = [POPSpringAnimation animationWithPropertyNamed:kPOPLa
 anim.toValue = [NSValue valueWithCGRect:CGRectMake(0, 0, 400, 400)];
 [layer pop_addAnimation:anim forKey:@"size"];
 ```
-Decay animations can be used to gradually slow an object to a halt. In this example, we decay a layer's positionX from it's current value and vecocity 1000pts per second:
+Decay animations can be used to gradually slow an object to a halt. In this example, we decay a layer's positionX from it's current value and velocity 1000pts per second:
 
 ```objective-c
 POPDecayAnimation *anim = [POPDecayAnimation animationWithPropertyNamed:kPOPLayerPositionX];


### PR DESCRIPTION
There was a spelling error in the README, `velocity` was spelt `vecocity`.
