### PR TITLE
Convert table view properties to scroll view properties

### DIFF
--- a/pop/POPAnimatableProperty.h
+++ b/pop/POPAnimatableProperty.h
@@ -135,10 +135,10 @@ extern NSString * const kPOPViewSize;
 
 
 /**
- Common UITableView property names.
+ Common UIScrollView property names.
  */
-extern NSString * const kPOPTableViewContentOffset;
-extern NSString * const kPOPTableViewContentSize;
+extern NSString * const kPOPScrollViewContentOffset;
+extern NSString * const kPOPScrollViewContentSize;
 
 
 #endif

--- a/pop/POPAnimatableProperty.mm
+++ b/pop/POPAnimatableProperty.mm
@@ -17,7 +17,7 @@
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIView.h>
-#import <UIKit/UITableView.h>
+#import <UIKit/UIScrollView.h>
 #else
 #import <AppKit/NSLayoutConstraint.h>
 #endif
@@ -60,8 +60,8 @@ NSString * const kPOPViewScaleXY = @"view.scaleXY";
 NSString * const kPOPViewScaleY = @"view.scaleY";
 NSString * const kPOPViewSize = kPOPLayerSize;
 
-NSString * const kPOPTableViewContentOffset = @"tableView.contentOffset";
-NSString * const kPOPTableViewContentSize = @"tableView.contentSize";
+NSString * const kPOPScrollViewContentOffset = @"scrollView.contentOffset";
+NSString * const kPOPScrollViewContentSize = @"scrollView.contentSize";
 
 
 /**
@@ -406,23 +406,23 @@ static POPStaticAnimatablePropertyState _staticStates[] =
     0.005
   },
   
-  /* UITableView */
+  /* UIScrollView */
   
-  {kPOPTableViewContentOffset,
-    ^(UITableView *obj, CGFloat values[]) {
+  {kPOPScrollViewContentOffset,
+    ^(UIScrollView *obj, CGFloat values[]) {
       values_from_point(values, obj.contentOffset);
     },
-    ^(UITableView *obj, const CGFloat values[]) {
+    ^(UIScrollView *obj, const CGFloat values[]) {
       obj.contentOffset = values_to_point(values);
     },
     1.0
   },
 
-  {kPOPTableViewContentSize,
-    ^(UITableView *obj, CGFloat values[]) {
+  {kPOPScrollViewContentSize,
+    ^(UIScrollView *obj, CGFloat values[]) {
       values_from_size(values, obj.contentSize);
     },
-    ^(UITableView *obj, const CGFloat values[]) {
+    ^(UIScrollView *obj, const CGFloat values[]) {
       obj.contentSize = values_to_size(values);
     },
     1.0


### PR DESCRIPTION
There's no reason for these property animations to be table view specific. They'll work for any scroll view.
