### PR TITLE
Fixed a condition check issue

### DIFF
--- a/pop/POPSpringAnimationInternal.h
+++ b/pop/POPSpringAnimationInternal.h
@@ -34,7 +34,7 @@ struct _POPSpringAnimationState : _POPPropertyAnimationState
   bool hasConverged()
   {
     NSUInteger count = valueCount;
-    if (shouldRound()) {
+    if (!shouldRound()) {
       return vec_equal(previous2Vec, previousVec) && vec_equal(previousVec, toVec);
     } else {
       if (!previousVec || !previous2Vec)


### PR DESCRIPTION
The `shouldRound ()` condition encountered a ‘equal’ behaviour.
