### PR TITLE
Cancelling any ongoing UIScrollView animation

### DIFF
--- a/pop/POPAnimatableProperty.mm
+++ b/pop/POPAnimatableProperty.mm
@@ -565,7 +565,7 @@ static POPStaticAnimatablePropertyState _staticStates[] =
       values_from_point(values, obj.contentOffset);
     },
     ^(UIScrollView *obj, const CGFloat values[]) {
-      obj.contentOffset = values_to_point(values);
+      [obj setContentOffset:values_to_point(values) animated:NO];
     },
     kPOPThresholdPoint
   },


### PR DESCRIPTION
If there is any UIScrollView animation of any sort:
- Say the user scrolled a little bit and the UIScrollView is decelerating. 
- Or `[scrollView setContentOffSet:p animated:YES]` was triggered.
- Or the user tapped on the statusbar to scroll to top

These animations will interfere with pop-animation since they will both work simultaneously. Setting `-[UIScrollView setContentOffset:animated:]` will cancel/stop any UIScrollView animation.
