### PR TITLE
Fixed typo in `#if !TARGET_OS_**I**PHONE`

### DIFF
--- a/pop/POPAnimatorPrivate.h
+++ b/pop/POPAnimatorPrivate.h
@@ -23,7 +23,7 @@
 
 @interface POPAnimator ()
 
-#if !TARGET_OS_PHONE
+#if !TARGET_OS_IPHONE
 /**
  Determines whether or not to use a high priority background thread for animation updates. Using a background thread can result in faster, more responsive updates, but may be less compatible. Defaults to YES.
  */


### PR DESCRIPTION
```
-#if !TARGET_OS_PHONE
+#if !TARGET_OS_IPHONE
```
