### PR TITLE
Update master to point to 1.0.6

### DIFF
--- a/pop.podspec
+++ b/pop.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name         = 'pop'
-  spec.version      = '1.0.5'
+  spec.version      = '1.0.6'
   spec.license      =  { :type => 'BSD' }
   spec.homepage     = 'https://github.com/facebook/pop'
   spec.authors      = { 'Kimon Tsinteris' => 'kimon@mac.com' }
   spec.summary      = 'Extensible animation framework for iOS and OS X.'
-  spec.source       = { :git => 'https://github.com/facebook/pop.git', :tag => '1.0.5' }
+  spec.source       = { :git => 'https://github.com/facebook/pop.git', :tag => '1.0.6' }
   spec.source_files = 'pop/**/*.{h,m,mm,cpp}'
   spec.public_header_files = 'pop/{POP,POPAnimatableProperty,POPAnimation,POPAnimationEvent,POPAnimationExtras,POPAnimationTracer,POPAnimator,POPBasicAnimation,POPCustomAnimation,POPDecayAnimation,POPDefines,POPGeometry,POPLayerExtras,POPPropertyAnimation,POPSpringAnimation}.h'
   spec.requires_arc = true


### PR DESCRIPTION
Seems 1.0.6 was tagged properly but the podspec here is out of date. I was confused when CocoaPods told me I downgraded when I pointed to master. I merged @kimon's commit for 1.0.6.
