### PR TITLE
Support animating UIEdgeInsets on iOS

### DIFF
--- a/pop-tests/POPAnimationTests.mm
+++ b/pop-tests/POPAnimationTests.mm
@@ -416,9 +416,24 @@ using namespace POP;
   STAssertEqualObjects(anim2.toValue, rectValue, @"property value read should equal write");
   STAssertEqualObjects(anim2.velocity, rectValue, @"property value read should equal write");
 
+#if TARGET_OS_IPHONE
+
   POPSpringAnimation *anim3 = [POPSpringAnimation animation];
+
+  id edgeInsetsValue = [NSValue valueWithUIEdgeInsets:UIEdgeInsetsMake(20, 40, 20, 40)];
+  anim3.fromValue = edgeInsetsValue;
+  anim3.toValue = edgeInsetsValue;
+  anim3.velocity = edgeInsetsValue;
+
+  STAssertEqualObjects(anim3.fromValue, edgeInsetsValue, @"property value read should equal write");
+  STAssertEqualObjects(anim3.toValue, edgeInsetsValue, @"property value read should equal write");
+  STAssertEqualObjects(anim3.velocity, edgeInsetsValue, @"property value read should equal write");
+
+#endif
+
+  POPSpringAnimation *anim4 = [POPSpringAnimation animation];
   id transformValue = [NSValue valueWithCATransform3D:CATransform3DIdentity];
-  STAssertThrows(anim3.fromValue = transformValue, @"should not be able to set %@", transformValue);
+  STAssertThrows(anim4.fromValue = transformValue, @"should not be able to set %@", transformValue);
 }
 
 - (void)testTracer

--- a/pop/POPAnimationRuntime.h
+++ b/pop/POPAnimationRuntime.h
@@ -21,6 +21,7 @@ enum POPValueType
   kPOPValuePoint,
   kPOPValueSize,
   kPOPValueRect,
+  kPOPValueEdgeInsets,
   kPOPValueAffineTransform,
   kPOPValueTransform,
   kPOPValueRange,
@@ -42,12 +43,12 @@ extern POPValueType POPSelectValueType(id obj, const POPValueType *types, size_t
 /**
  Array of all value types.
  */
-extern const POPValueType kPOPAnimatableAllTypes[9];
+extern const POPValueType kPOPAnimatableAllTypes[10];
 
 /**
  Array of all value types supported for animation.
  */
-extern const POPValueType kPOPAnimatableSupportTypes[7];
+extern const POPValueType kPOPAnimatableSupportTypes[8];
 
 /**
  Returns a string description of a value type.

--- a/pop/POPAnimationRuntime.mm
+++ b/pop/POPAnimationRuntime.mm
@@ -14,9 +14,7 @@
 #import <QuartzCore/QuartzCore.h>
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIScreen.h>
-#else
-#import <AppKit/NSScreen.h>
+#import <UIKit/UIKit.h>
 #endif
 
 #import "POPVector.h"
@@ -98,6 +96,13 @@ static bool FBCompareTypeEncoding(const char *objctype, POPValueType type)
 #endif
               );
 
+    case kPOPValueEdgeInsets:
+#if TARGET_OS_IPHONE
+      return strcmp(objctype, @encode(UIEdgeInsets)) == 0;
+#else
+      return false;
+#endif
+
     case kPOPValueAffineTransform:
       return strcmp(objctype, @encode(CGAffineTransform)) == 0;
 
@@ -144,9 +149,9 @@ POPValueType POPSelectValueType(id obj, const POPValueType *types, size_t length
   return kPOPValueUnknown;
 }
 
-const POPValueType kPOPAnimatableAllTypes[9] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueAffineTransform, kPOPValueTransform, kPOPValueRange, kPOPValueColor};
+const POPValueType kPOPAnimatableAllTypes[10] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueEdgeInsets, kPOPValueAffineTransform, kPOPValueTransform, kPOPValueRange, kPOPValueColor};
 
-const POPValueType kPOPAnimatableSupportTypes[7] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueColor};
+const POPValueType kPOPAnimatableSupportTypes[8] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueEdgeInsets, kPOPValueColor};
 
 NSString *POPValueTypeToString(POPValueType t)
 {
@@ -163,6 +168,8 @@ NSString *POPValueTypeToString(POPValueType t)
       return @"CGSize";
     case kPOPValueRect:
       return @"CGRect";
+    case kPOPValueEdgeInsets:
+      return @"UIEdgeInsets";
     case kPOPValueAffineTransform:
       return @"CGAffineTransform";
     case kPOPValueTransform:
@@ -195,6 +202,11 @@ id POPBox(VectorConstRef vec, POPValueType type, bool force)
     case kPOPValueRect:
       return [NSValue valueWithCGRect:vec->cg_rect()];
       break;
+#if TARGET_OS_IPHONE
+    case kPOPValueEdgeInsets:
+      return [NSValue valueWithUIEdgeInsets:vec->ui_edge_insets()];
+      break;
+#endif
     case kPOPValueColor: {
       return (__bridge_transfer id)vec->cg_color();
       break;
@@ -223,6 +235,11 @@ static VectorRef vectorize(id value, POPValueType type)
     case kPOPValueRect:
       vec = Vector::new_cg_rect([value CGRectValue]);
       break;
+#if TARGET_OS_IPHONE
+    case kPOPValueEdgeInsets:
+      vec = Vector::new_ui_edge_insets([value UIEdgeInsetsValue]);
+      break;
+#endif
     case kPOPValueAffineTransform:
       vec = Vector::new_cg_affine_transform([value CGAffineTransformValue]);
       break;

--- a/pop/POPCGUtils.h
+++ b/pop/POPCGUtils.h
@@ -8,6 +8,9 @@
  */
 
 #import <CoreGraphics/CoreGraphics.h>
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
 #import "POPDefines.h"
 
 #if TARGET_OS_IPHONE
@@ -31,6 +34,15 @@ NS_INLINE CGRect values_to_rect(const CGFloat values[])
   return CGRectMake(values[0], values[1], values[2], values[3]);
 }
 
+#if TARGET_OS_IPHONE
+
+NS_INLINE UIEdgeInsets values_to_edge_insets(const CGFloat values[])
+{
+  return UIEdgeInsetsMake(values[0], values[1], values[2], values[3]);
+}
+
+#endif
+
 NS_INLINE void values_from_point(CGFloat values[], CGPoint p)
 {
   values[0] = p.x;
@@ -50,6 +62,18 @@ NS_INLINE void values_from_rect(CGFloat values[], CGRect r)
   values[2] = r.size.width;
   values[3] = r.size.height;
 }
+
+#if TARGET_OS_IPHONE
+
+NS_INLINE void values_from_edge_insets(CGFloat values[], UIEdgeInsets i)
+{
+  values[0] = i.top;
+  values[1] = i.left;
+  values[2] = i.bottom;
+  values[3] = i.right;
+}
+
+#endif
 
 /**
  Takes a CGColorRef and converts it into RGBA components, if necessary.

--- a/pop/POPDecayAnimation.mm
+++ b/pop/POPDecayAnimation.mm
@@ -9,7 +9,11 @@
 
 #import "POPDecayAnimationInternal.h"
 
-const POPValueType supportedVelocityTypes[5] = { kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, kPOPValueSize };
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
+const POPValueType supportedVelocityTypes[6] = { kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, kPOPValueSize, kPOPValueEdgeInsets };
 
 @implementation POPDecayAnimation
 
@@ -95,6 +99,12 @@ DEFINE_RW_PROPERTY(POPDecayAnimationState, deceleration, setDeceleration:, CGFlo
     CGSize originalVelocitySize = [self.originalVelocity CGSizeValue];
     CGSize negativeOriginalVelocitySize = CGSizeMake(-originalVelocitySize.width, -originalVelocitySize.height);
     reversedVelocity = [NSValue valueWithCGSize:negativeOriginalVelocitySize];
+  } else if (velocityType == kPOPValueEdgeInsets) {
+#if TARGET_OS_IPHONE
+    UIEdgeInsets originalVelocityInsets = [self.originalVelocity UIEdgeInsetsValue];
+    UIEdgeInsets negativeOriginalVelocityInsets = UIEdgeInsetsMake(-originalVelocityInsets.top, -originalVelocityInsets.left, -originalVelocityInsets.bottom, -originalVelocityInsets.right);
+    reversedVelocity = [NSValue valueWithUIEdgeInsets:negativeOriginalVelocityInsets];
+#endif
   }
 
   return reversedVelocity;

--- a/pop/POPVector.h
+++ b/pop/POPVector.h
@@ -15,6 +15,9 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <objc/NSObjCRuntime.h>
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
 #import "POPMath.h"
 
 namespace POP {
@@ -319,6 +322,12 @@ namespace POP {
     // CGRect support
     CGRect cg_rect() const;
     static Vector *new_cg_rect(const CGRect &r);
+
+#if TARGET_OS_IPHONE
+    // UIEdgeInsets support
+    UIEdgeInsets ui_edge_insets() const;
+    static Vector *new_ui_edge_insets(const UIEdgeInsets &i);
+#endif
 
     // CGAffineTransform support
     CGAffineTransform cg_affine_transform() const;

--- a/pop/POPVector.mm
+++ b/pop/POPVector.mm
@@ -188,6 +188,25 @@ namespace POP
     return v;
   }
 
+#if TARGET_OS_IPHONE
+
+  UIEdgeInsets Vector::ui_edge_insets() const
+  {
+    return _count < 4 ? UIEdgeInsetsZero : UIEdgeInsetsMake(_values[0], _values[1], _values[2], _values[3]);
+  }
+
+  Vector *Vector::new_ui_edge_insets(const UIEdgeInsets &i)
+  {
+    Vector *v = new Vector(4);
+    v->_values[0] = i.top;
+    v->_values[1] = i.left;
+    v->_values[2] = i.bottom;
+    v->_values[3] = i.right;
+    return v;
+  }
+  
+#endif
+
   CGAffineTransform Vector::cg_affine_transform() const
   {
     if (_count < 6) {


### PR DESCRIPTION
Adds basic support for UIEdgeInsets. Currently only supporting iOS because edge
insets aren't as common to work with on OS X (e.g. NSScrollView doesn't have
a contentInset property).

Added tests and verified they all pass on the 32- and 64-bit iOS simulators and
under the pop-osx project as well.
