### PR TITLE
Re-lock after removing existing animation in addAnimation:forObject:key

### DIFF
--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -544,10 +544,14 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
     if (existingAnim) {
       // unlock
       OSSpinLockUnlock(&_lock);
+
       if (existingAnim == anim) {
         return;
       }
       [self removeAnimationForObject:obj key:key cleanupDict:NO];
+        
+      // lock
+      OSSpinLockLock(&_lock);
     }
   }
   keyAnimationDict[key] = anim;


### PR DESCRIPTION
The existing code unlocks but doesn't re-lock in the event that we remove the existing animation and carry on to add the new one (falling through the if block). The code then goes on to attempt to unlock the lock, which isn't locked.

(At first I thought perhaps the unlock should only happen in the case that existingAnim  == anim, but as removeAnimationForObject:key:cleanupDict: also locks it, I hope this is the right solution)
