### PR TITLE
POP->pop to reflect filesystem naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Alternatively, you can add the project to your workspace and adopt the provided 
 Pop adopts the Core Animation explicit animation programming model. Use by including the following import:
 
 ```objective-c
-#import <POP/POP.h>
+#import <pop/POP.h>
 ```
 
 ### Start, Stop & Update

--- a/pop-tests/POPAnimatable.mm
+++ b/pop-tests/POPAnimatable.mm
@@ -9,7 +9,7 @@
 
 #import "POPAnimatable.h"
 
-#import <POP/POP.h>
+#import <pop/POP.h>
 
 @implementation POPAnimatable
 {

--- a/pop-tests/POPAnimatablePropertyTests.mm
+++ b/pop-tests/POPAnimatablePropertyTests.mm
@@ -9,7 +9,7 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 
-#import <POP/POPAnimatableProperty.h>
+#import <pop/POPAnimatableProperty.h>
 
 static const CGFloat epsilon = 0.0001f;
 static NSArray *properties = @[@"name", @"readBlock", @"writeBlock", @"threshold"];

--- a/pop-tests/POPAnimationMRRTests.mm
+++ b/pop-tests/POPAnimationMRRTests.mm
@@ -12,8 +12,8 @@
 #import <OCMock/OCMock.h>
 #import <SenTestingKit/SenTestingKit.h>
 
-#import <POP/POP.h>
-#import <POP/POPAnimatorPrivate.h>
+#import <pop/POP.h>
+#import <pop/POPAnimatorPrivate.h>
 
 #import "POPAnimationTestsExtras.h"
 

--- a/pop-tests/POPAnimationTests.mm
+++ b/pop-tests/POPAnimationTests.mm
@@ -12,9 +12,9 @@
 #import <OCMock/OCMock.h>
 #import <SenTestingKit/SenTestingKit.h>
 
-#import <POP/POP.h>
-#import <POP/POPAnimationPrivate.h>
-#import <POP/POPAnimatorPrivate.h>
+#import <pop/POP.h>
+#import <pop/POPAnimationPrivate.h>
+#import <pop/POPAnimatorPrivate.h>
 
 #import "POPAnimatable.h"
 #import "POPAnimationRuntime.h"

--- a/pop-tests/POPAnimationTestsExtras.mm
+++ b/pop-tests/POPAnimationTestsExtras.mm
@@ -9,8 +9,8 @@
 
 #import "POPAnimationTestsExtras.h"
 
-#import <POP/POP.h>
-#import <POP/POPAnimatorPrivate.h>
+#import <pop/POP.h>
+#import <pop/POPAnimatorPrivate.h>
 
 void POPAnimatorRenderTime(POPAnimator *animator, CFTimeInterval beginTime, CFTimeInterval time)
 {

--- a/pop-tests/POPBaseAnimationTests.mm
+++ b/pop-tests/POPBaseAnimationTests.mm
@@ -13,8 +13,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import <POP/POP.h>
-#import <POP/POPAnimatorPrivate.h>
+#import <pop/POP.h>
+#import <pop/POPAnimatorPrivate.h>
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPBasicAnimationTests.mm
+++ b/pop-tests/POPBasicAnimationTests.mm
@@ -10,7 +10,7 @@
 #import <SenTestingKit/SenTestingKit.h>
 
 #import <OCMock/OCMock.h>
-#import <POP/POPBasicAnimation.h>
+#import <pop/POPBasicAnimation.h>
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPCustomAnimationTests.mm
+++ b/pop-tests/POPCustomAnimationTests.mm
@@ -10,7 +10,7 @@
 #import <SenTestingKit/SenTestingKit.h>
 
 #import <OCMock/OCMock.h>
-#import <POP/POPCustomAnimation.h>
+#import <pop/POPCustomAnimation.h>
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPDecayAnimationTests.mm
+++ b/pop-tests/POPDecayAnimationTests.mm
@@ -12,8 +12,8 @@
 #import <OCMock/OCMock.h>
 #import <SenTestingKit/SenTestingKit.h>
 
-#import <POP/POP.h>
-#import <POP/POPAnimatorPrivate.h>
+#import <pop/POP.h>
+#import <pop/POPAnimatorPrivate.h>
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPEaseInEaseOutAnimationTests.mm
+++ b/pop-tests/POPEaseInEaseOutAnimationTests.mm
@@ -12,8 +12,8 @@
 #import <OCMock/OCMock.h>
 #import <SenTestingKit/SenTestingKit.h>
 
-#import <POP/POP.h>
-#import <POP/POPAnimatorPrivate.h>
+#import <pop/POP.h>
+#import <pop/POPAnimatorPrivate.h>
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPSpringAnimationTests.mm
+++ b/pop-tests/POPSpringAnimationTests.mm
@@ -12,11 +12,11 @@
 #import <OCMock/OCMock.h>
 #import <QuartzCore/QuartzCore.h>
 
-#import <POP/POPAnimation.h>
-#import <POP/POPAnimationPrivate.h>
-#import <POP/POPAnimator.h>
-#import <POP/POPAnimatorPrivate.h>
-#import <POP/POPAnimationExtras.h>
+#import <pop/POPAnimation.h>
+#import <pop/POPAnimationPrivate.h>
+#import <pop/POPAnimator.h>
+#import <pop/POPAnimatorPrivate.h>
+#import <pop/POPAnimationExtras.h>
 
 #import "POPAnimatable.h"
 #import "POPAnimationInternal.h"

--- a/pop.xcodeproj/project.pbxproj
+++ b/pop.xcodeproj/project.pbxproj
@@ -1115,7 +1115,7 @@
 			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
 			buildSettings = {
 				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
 			};
@@ -1133,7 +1133,7 @@
 			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
 			buildSettings = {
 				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
 			};
@@ -1158,7 +1158,7 @@
 			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
 			buildSettings = {
 				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
 			};
@@ -1169,7 +1169,7 @@
 			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
 			buildSettings = {
 				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
 			};
@@ -1184,7 +1184,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 			};
 			name = Debug;
@@ -1198,7 +1198,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 			};
 			name = GCOV;
@@ -1212,7 +1212,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 			};
 			name = Release;
@@ -1226,7 +1226,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
-				INFOPLIST_FILE = "POP/pop-Info.plist";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
 				PRODUCT_NAME = pop;
 			};
 			name = Profile;

--- a/pop/POP.h
+++ b/pop/POP.h
@@ -10,19 +10,19 @@
 #ifndef POP_POP_H
 #define POP_POP_H
 
-#import <POP/POPAnimatableProperty.h>
-#import <POP/POPAnimation.h>
-#import <POP/POPAnimationEvent.h>
-#import <POP/POPAnimationExtras.h>
-#import <POP/POPAnimationTracer.h>
-#import <POP/POPAnimator.h>
-#import <POP/POPBasicAnimation.h>
-#import <POP/POPCustomAnimation.h>
-#import <POP/POPDecayAnimation.h>
-#import <POP/POPDefines.h>
-#import <POP/POPGeometry.h>
-#import <POP/POPPropertyAnimation.h>
-#import <POP/POPSpringAnimation.h>
+#import <pop/POPAnimatableProperty.h>
+#import <pop/POPAnimation.h>
+#import <pop/POPAnimationEvent.h>
+#import <pop/POPAnimationExtras.h>
+#import <pop/POPAnimationTracer.h>
+#import <pop/POPAnimator.h>
+#import <pop/POPBasicAnimation.h>
+#import <pop/POPCustomAnimation.h>
+#import <pop/POPDecayAnimation.h>
+#import <pop/POPDefines.h>
+#import <pop/POPGeometry.h>
+#import <pop/POPPropertyAnimation.h>
+#import <pop/POPSpringAnimation.h>
 
 
 #endif /* POP_POP_H */

--- a/pop/POPAction.h
+++ b/pop/POPAction.h
@@ -11,7 +11,7 @@
 #define POPACTION_H
 
 #import <QuartzCore/CATransaction.h>
-#import <POP/POPDefines.h>
+#import <pop/POPDefines.h>
 
 #ifdef __cplusplus
 

--- a/pop/POPAnimatableProperty.mm
+++ b/pop/POPAnimatableProperty.mm
@@ -13,7 +13,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-#import <POP/POPLayerExtras.h>
+#import <pop/POPLayerExtras.h>
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>

--- a/pop/POPAnimation.h
+++ b/pop/POPAnimation.h
@@ -9,8 +9,8 @@
 
 #import <Foundation/NSObject.h>
 
-#import <POP/POPAnimationTracer.h>
-#import <POP/POPGeometry.h>
+#import <pop/POPAnimationTracer.h>
+#import <pop/POPGeometry.h>
 
 @class CAMediaTimingFunction;
 

--- a/pop/POPAnimationExtras.h
+++ b/pop/POPAnimationExtras.h
@@ -9,8 +9,8 @@
 
 #import <QuartzCore/CAAnimation.h>
 
-#import <POP/POPDefines.h>
-#import <POP/POPSpringAnimation.h>
+#import <pop/POPDefines.h>
+#import <pop/POPSpringAnimation.h>
 
 /**
  @abstract The current drag coefficient.

--- a/pop/POPAnimationPrivate.h
+++ b/pop/POPAnimationPrivate.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <POP/POPAnimation.h>
+#import <pop/POPAnimation.h>
 
 #define POP_ANIMATION_FRICTION_FOR_QC_FRICTION(qcFriction) (25.0 + (((qcFriction - 8.0) / 2.0) * (25.0 - 19.0)))
 #define POP_ANIMATION_TENSION_FOR_QC_TENSION(qcTension) (194.0 + (((qcTension - 30.0) / 50.0) * (375.0 - 194.0)))

--- a/pop/POPAnimationTracer.h
+++ b/pop/POPAnimationTracer.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <POP/POPAnimationEvent.h>
+#import <pop/POPAnimationEvent.h>
 
 @class POPAnimation;
 

--- a/pop/POPAnimationTracerInternal.h
+++ b/pop/POPAnimationTracerInternal.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <POP/POPAnimationTracer.h>
+#import <pop/POPAnimationTracer.h>
 
 @interface POPAnimationTracer (Internal)
 

--- a/pop/POPAnimatorPrivate.h
+++ b/pop/POPAnimatorPrivate.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <POP/POPAnimator.h>
+#import <pop/POPAnimator.h>
 
 @class POPAnimation;
 

--- a/pop/POPBasicAnimation.h
+++ b/pop/POPBasicAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <POP/POPPropertyAnimation.h>
+#import <pop/POPPropertyAnimation.h>
 
 /**
  @abstract A concrete basic animation class.

--- a/pop/POPCustomAnimation.h
+++ b/pop/POPCustomAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <POP/POPAnimation.h>
+#import <pop/POPAnimation.h>
 
 @class POPCustomAnimation;
 

--- a/pop/POPDecayAnimation.h
+++ b/pop/POPDecayAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <POP/POPPropertyAnimation.h>
+#import <pop/POPPropertyAnimation.h>
 
 /**
  @abstract A concrete decay animation class.

--- a/pop/POPLayerExtras.h
+++ b/pop/POPLayerExtras.h
@@ -9,7 +9,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-#import <POP/POPDefines.h>
+#import <pop/POPDefines.h>
 
 POP_EXTERN_C_BEGIN
 

--- a/pop/POPPropertyAnimation.h
+++ b/pop/POPPropertyAnimation.h
@@ -7,8 +7,8 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <POP/POPAnimatableProperty.h>
-#import <POP/POPAnimation.h>
+#import <pop/POPAnimatableProperty.h>
+#import <pop/POPAnimation.h>
 
 /**
  @abstract Flags for clamping animation values.

--- a/pop/POPSpringAnimation.h
+++ b/pop/POPSpringAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <POP/POPPropertyAnimation.h>
+#import <pop/POPPropertyAnimation.h>
 
 /**
  @abstract A concrete spring animation class.


### PR DESCRIPTION
Fixes #78.

Using POP is unwise as git won't necessarily update people on case-insensitive filesystems, I think. In addition, the pod is named 'pop', rather than 'POP', and it's a good idea to `#import <podnamehere/SomeHeader.h>` for consistency.

Having non-case-sensitive folks either re-pull or potentially deal with case problems if they move their repo to a case-sensitive filesystem doesn't seem like a good idea; going with "POP" on the filesystem would probably be a significantly negative developer experience given that 'pop' is more consistent and what's already on disk.

@kimon this really isn't a CocoaPods issue, as the podspec correctly identifies the filesystem paths as pop/whatever. It does go a little wild on specifying exported headers explicitly instead of using the folder hierarchy for conciseness, but that's not a big deal.

I've modified all references to the pop folder. I checked as such:

```
% git grep -h "POP" | grep import | sort -u
% git grep -h "POP/" | sort -u
% git grep -h "pop/" | sort -u
```
