### PR TITLE
Use time progress to determine basic animation end.

### DIFF
--- a/pop/POPBasicAnimationInternal.h
+++ b/pop/POPBasicAnimationInternal.h
@@ -38,11 +38,13 @@ struct _POPBasicAnimationState : _POPPropertyAnimationState
   CAMediaTimingFunction *timingFunction;
   double timingControlPoints[4];
   CFTimeInterval duration;
+  CFTimeInterval timeProgress;
 
   _POPBasicAnimationState(id __unsafe_unretained anim) : _POPPropertyAnimationState(anim),
   timingFunction(nil),
   timingControlPoints{0.},
-  duration(kPOPAnimationDurationDefault)
+  duration(kPOPAnimationDurationDefault),
+  timeProgress(0.)
   {
     type = kPOPAnimationBasic;
   }
@@ -51,7 +53,7 @@ struct _POPBasicAnimationState : _POPPropertyAnimationState
     if (_POPPropertyAnimationState::isDone()) {
       return true;
     }
-    return progress + kPOPProgressThreshold >= 1.;
+    return timeProgress + kPOPProgressThreshold >= 1.;
   }
 
   void updatedTimingFunction()
@@ -76,6 +78,9 @@ struct _POPBasicAnimationState : _POPPropertyAnimationState
         // cap local time to duration
         CFTimeInterval t = MIN(time - startTime, duration) / duration;
         p = POPTimingFunctionSolve(timingControlPoints, t, SOLVE_EPS(duration));
+        timeProgress = t;
+    } else {
+        timeProgress = 1.;
     }
 
     // interpolate and advance


### PR DESCRIPTION
If the timing function goes over 1.0 the animation stops at that point (issue #91). This commit should fix that.
