### PR TITLE
Fixed support of edge insets with POPBasicAnimation

### DIFF
--- a/pop-tests/POPBasicAnimationTests.mm
+++ b/pop-tests/POPBasicAnimationTests.mm
@@ -83,4 +83,50 @@
     POPAssertColorEqual((__bridge CGColorRef)anim.toValue, layer.backgroundColor);
 }
 
+#if TARGET_OS_IPHONE
+- (void)testEdgeInsetsSupport
+{
+  const UIEdgeInsets fromEdgeInsets = UIEdgeInsetsZero;
+  const UIEdgeInsets toEdgeInsets = UIEdgeInsetsMake(100, 200, 200, 400);
+  
+  POPBasicAnimation *anim = [POPBasicAnimation animationWithPropertyNamed:kPOPScrollViewContentInset];
+  anim.fromValue = [NSValue valueWithUIEdgeInsets:fromEdgeInsets];
+  anim.toValue = [NSValue valueWithUIEdgeInsets:toEdgeInsets];
+  
+  id delegate = [OCMockObject niceMockForProtocol:@protocol(POPAnimationDelegate)];
+  anim.delegate = delegate;
+  
+  // expect start and stop to be called
+  [[delegate expect] pop_animationDidStart:anim];
+  [[delegate expect] pop_animationDidStop:anim finished:YES];
+  
+  // start tracer
+  POPAnimationTracer *tracer = anim.tracer;
+  [tracer start];
+  
+  id scrollView = [OCMockObject niceMockForClass:[UIScrollView class]];
+  [scrollView pop_addAnimation:anim forKey:nil];
+  
+  // expect final value to be set
+  [[scrollView expect] setContentInset:toEdgeInsets];
+  
+  // run animation
+  POPAnimatorRenderDuration(self.animator, self.beginTime, 3, 1.0/60.0);
+  
+  NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
+  
+  // verify delegate
+  [delegate verify];
+  
+  // verify scroll view
+  [scrollView verify];
+  
+  POPAnimationValueEvent *lastEvent = [writeEvents lastObject];
+  UIEdgeInsets lastEdgeInsets = [lastEvent.value UIEdgeInsetsValue];
+  
+  // verify last insets are to insets
+  STAssertTrue(UIEdgeInsetsEqualToEdgeInsets(lastEdgeInsets, toEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
+}
+#endif
+
 @end

--- a/pop-tests/POPDecayAnimationTests.mm
+++ b/pop-tests/POPDecayAnimationTests.mm
@@ -428,14 +428,13 @@ static const CGFloat epsilon = 0.0001f;
 }
 
 #if TARGET_OS_IPHONE
-
 - (void)testEdgeInsetsSupport
 {
   const UIEdgeInsets fromEdgeInsets = UIEdgeInsetsZero;
   const UIEdgeInsets velocityEdgeInsets = UIEdgeInsetsMake(100, 100, 1000, 1000);
 
   POPDecayAnimation *anim = [POPDecayAnimation animation];
-  anim.property = [POPAnimatableProperty propertyWithName:kPOPLayerBounds];
+  anim.property = [POPAnimatableProperty propertyWithName:kPOPScrollViewContentInset];
   anim.fromValue = [NSValue valueWithUIEdgeInsets:fromEdgeInsets];
   anim.velocity = [NSValue valueWithUIEdgeInsets:velocityEdgeInsets];
 
@@ -450,8 +449,8 @@ static const CGFloat epsilon = 0.0001f;
   POPAnimationTracer *tracer = anim.tracer;
   [tracer start];
 
-  CALayer *layer = self.layer1;
-  [layer pop_addAnimation:anim forKey:animationKey];
+  id scrollView = [OCMockObject niceMockForClass:[UIScrollView class]];
+  [scrollView pop_addAnimation:anim forKey:nil];
 
   // run animation
   POPAnimatorRenderDuration(self.animator, self.beginTime, 3, 1.0/60.0);
@@ -467,7 +466,6 @@ static const CGFloat epsilon = 0.0001f;
   STAssertTrue(!UIEdgeInsetsEqualToEdgeInsets(fromEdgeInsets, lastEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
   STAssertTrue(lastEdgeInsets.top == lastEdgeInsets.left && lastEdgeInsets.bottom == lastEdgeInsets.right && lastEdgeInsets.top < lastEdgeInsets.bottom, @"unexpected last edge insets value: %@", lastEvent);
 }
-
 #endif
 
 - (void)testEndValueOnReuse

--- a/pop-tests/POPSpringAnimationTests.mm
+++ b/pop-tests/POPSpringAnimationTests.mm
@@ -421,7 +421,6 @@ static NSString *animationKey = @"key";
 }
 
 #if TARGET_OS_IPHONE
-
 - (void)testEdgeInsetsSupport
 {
   const UIEdgeInsets fromEdgeInsets = UIEdgeInsetsZero;
@@ -429,7 +428,7 @@ static NSString *animationKey = @"key";
   const UIEdgeInsets velocityEdgeInsets = UIEdgeInsetsMake(1000, 1000, 1000, 1000);
 
   POPSpringAnimation *anim = [POPSpringAnimation animation];
-  anim.property = [POPAnimatableProperty propertyWithName:kPOPLayerBounds];
+  anim.property = [POPAnimatableProperty propertyWithName:kPOPScrollViewContentInset];
   anim.fromValue = [NSValue valueWithUIEdgeInsets:fromEdgeInsets];
   anim.toValue = [NSValue valueWithUIEdgeInsets:toEdgeInsets];
   anim.velocity = [NSValue valueWithUIEdgeInsets:velocityEdgeInsets];
@@ -444,8 +443,11 @@ static NSString *animationKey = @"key";
   POPAnimationTracer *tracer = anim.tracer;
   [tracer start];
 
-  CALayer *layer = [CALayer layer];
-  [layer pop_addAnimation:anim forKey:@""];
+  id scrollView = [OCMockObject niceMockForClass:[UIScrollView class]];
+  [scrollView pop_addAnimation:anim forKey:nil];
+
+  // expect final value to be set
+  [[scrollView expect] setContentInset:toEdgeInsets];
 
   // run animation
   POPAnimatorRenderDuration(self.animator, self.beginTime, 3, 1.0/60.0);
@@ -455,13 +457,15 @@ static NSString *animationKey = @"key";
   // verify delegate
   [delegate verify];
 
+  // verify scroll view
+  [scrollView verify];
+
   POPAnimationValueEvent *lastEvent = [writeEvents lastObject];
   UIEdgeInsets lastEdgeInsets = [lastEvent.value UIEdgeInsetsValue];
 
   // verify last insets are to insets
   STAssertTrue(UIEdgeInsetsEqualToEdgeInsets(lastEdgeInsets, toEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
 }
-
 #endif
 
 - (void)testColorSupport

--- a/pop/POPBasicAnimationInternal.h
+++ b/pop/POPBasicAnimationInternal.h
@@ -25,6 +25,7 @@ static void interpolate(POPValueType valueType, NSUInteger count, const CGFloat 
     case kPOPValueSize:
     case kPOPValueRect:
     case kPOPValueColor:
+    case kPOPValueEdgeInsets:
       POPInterpolateVector(count, outVec, fromVec, toVec, p);
       break;
     default:


### PR DESCRIPTION
The support for UIEdgeInsets added in #128 causes an assertion when animating using a POPBasicAnimation object. This fixes the problem and adds the related unit tests.
