### PR TITLE
Changes return value of id to instancetype

### DIFF
--- a/pop/POPAnimatableProperty.h
+++ b/pop/POPAnimatableProperty.h
@@ -23,7 +23,7 @@
  @return The animatable property with that name or nil if it does not exist.
  @discussion Common animatable properties are included by default. Use the provided constants to reference.
  */
-+ (id)propertyWithName:(NSString *)name;
++ (instancetype)propertyWithName:(NSString *)name;
 
 /**
  @abstract The designated initializer.
@@ -32,7 +32,7 @@
  @return The animatable property with name if it exists, otherwise a newly created instance configured by block.
  @discussion Custom properties should use reverse-DNS naming. A newly created instance is only mutable in the scope of block. Once constructed, a property becomes immutable.
  */
-+ (id)propertyWithName:(NSString *)name initializer:(void (^)(POPMutableAnimatableProperty *prop))block;
++ (instancetype)propertyWithName:(NSString *)name initializer:(void (^)(POPMutableAnimatableProperty *prop))block;
 
 /**
  @abstract The name of the property.

--- a/pop/POPAnimation.h
+++ b/pop/POPAnimation.h
@@ -157,6 +157,6 @@ When combined with the autoreverses property, a singular animation is effectivel
  @param key The key used to identify the animation.
  @returns The animation currently attached, or nil if no such animation exists.
  */
-- (id)pop_animationForKey:(NSString *)key;
+- (instancetype)pop_animationForKey:(NSString *)key;
 
 @end

--- a/pop/POPDecayAnimation.h
+++ b/pop/POPDecayAnimation.h
@@ -61,6 +61,6 @@
  @abstract The reversed velocity.
  @discussion The reversed velocity based on the originalVelocity when the animation was set up.
  */
-- (id)reversedVelocity;
+- (instancetype)reversedVelocity;
 
 @end


### PR DESCRIPTION
Uses the `instancetype` instead of vague `id`so that the Swift compiler can use these methods without ugly downcasting.
