### PR TITLE
Changed SceneKit Support to Opt-In

### DIFF
--- a/Configuration/Dynamic Libraries/DynamicLibrary-iOS.xcconfig
+++ b/Configuration/Dynamic Libraries/DynamicLibrary-iOS.xcconfig
@@ -18,4 +18,4 @@ PRODUCT_NAME = pop
 INFOPLIST_FILE = pop-embedded/Info.plist
 
 // Compiler Options,
-OTHER_LDFLAGS = $(inherited) -weak_framework UIKit -weak_framework QuartzCore -weak_framework CoreGraphics -weak_framework CoreImage -weak_framework SceneKit -ObjC
+OTHER_LDFLAGS = $(inherited) -weak_framework UIKit -weak_framework QuartzCore -weak_framework CoreGraphics -weak_framework CoreImage -ObjC

--- a/Configuration/Platform/Compiler.xcconfig
+++ b/Configuration/Platform/Compiler.xcconfig
@@ -34,6 +34,3 @@ CLANG_ENABLE_OBJC_ARC = YES
 
 // Allow #import'ing code generated headers from DERIVED_FILE_DIR.
 HEADER_SEARCH_PATHS = $(inherited) $(DERIVED_FILE_DIR)
-
-// Weakly Link SceneKit
-OTHER_LDFLAGS = $(inherited) -weak_framework SceneKit

--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ pod install
 
 Assuming CocoaPods is installed, this will include the necessary OCMock dependency to the unit test targets.
 
+## SceneKit
+
+Due to SceneKit requiring iOS 8 and OS X 10.9, POP's SceneKit extensions aren't provided out of box. Unfortunately, [weakly linked frameworks](https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html) cannot be used due to issues mentioned in the [Xcode 6.1 Release Notes](https://developer.apple.com/library/ios/releasenotes/DeveloperTools/RN-Xcode/Chapters/xc6_release_notes.html).
+
+To remedy this, you can easily opt-in to use SceneKit! Simply add this to the Preprocessor Macros section of your Xcode Project: 
+
+```
+POP_USE_SCENEKIT=1
+```
+
 ## Resources
 
 A collection of links to external resources that may prove valuable:

--- a/pop/POPDefines.h
+++ b/pop/POPDefines.h
@@ -29,9 +29,9 @@
 #endif
 
 #if TARGET_OS_MAC
-  #define SCENEKIT_SDK_AVAILABLE defined(__MAC_10_10)
+  #define SCENEKIT_SDK_AVAILABLE defined(POP_USE_SCENEKIT)
 #elif TARGET_OS_IPHONE
-  #define SCENEKIT_SDK_AVAILABLE defined(__IPHONE_8_0)
+  #define SCENEKIT_SDK_AVAILABLE defined(POP_USE_SCENEKIT)
 #endif
 
 #endif


### PR DESCRIPTION
Due to automagically weakly linking SceneKit in, this breaks use of the iOS simulator when targeting devices < iOS 8.0. Quoting from the Xcode 6.1 Release Notes:

```
If an app is weak linked against frameworks new in iOS 8 SDK and OS X 10.10 SDK, it may fail to run if the run destination is an iOS Simulator for older iOS runtimes and the host system is running OS X Yosemite. (17807439)
```

SceneKit is now opt-in only with use of POP_USE_SCENEKIT=1.