### PR TITLE
Switch from SenTestingKit to XCTest

### DIFF
--- a/Configuration/Tests/LogicTests-OSX.xcconfig
+++ b/Configuration/Tests/LogicTests-OSX.xcconfig
@@ -14,10 +14,10 @@ DSTROOT = /tmp/$(TARGET_NAME)
 SKIP_INSTALL = YES
 
 // Linking
-OTHER_LDFLAGS = -framework SenTestingKit -all_load -lc++
+OTHER_LDFLAGS = -framework XCTest -all_load -lc++
 
 // Packaging
-WRAPPER_EXTENSION = octest
+WRAPPER_EXTENSION = xctest
 
 // Search Paths
-FRAMEWORK_SEARCH_PATHS = $(DEVELOPER_FRAMEWORKS_DIR)
+FRAMEWORK_SEARCH_PATHS = $(PLATFORM_DIR)/Developer/Library/Frameworks $(DEVELOPER_FRAMEWORKS_DIR)

--- a/Configuration/Tests/LogicTests-iOS.xcconfig
+++ b/Configuration/Tests/LogicTests-iOS.xcconfig
@@ -17,10 +17,10 @@ DSTROOT = /tmp/$(TARGET_NAME)
 SKIP_INSTALL = YES
 
 // Linking
-OTHER_LDFLAGS = -framework SenTestingKit -all_load -lc++
+OTHER_LDFLAGS = -framework XCTest -all_load -lc++
 
 // Packaging
-WRAPPER_EXTENSION = octest
+WRAPPER_EXTENSION = xctest
 
 // Search Paths
 FRAMEWORK_SEARCH_PATHS = $(SDKROOT)/Developer/Library/Frameworks $(DEVELOPER_FRAMEWORKS_DIR)

--- a/Podfile
+++ b/Podfile
@@ -8,3 +8,25 @@ target :'pop-tests-osx', :exclusive => true do
   platform :osx, '10.9'
   pod 'OCMock', '~> 2.2'
 end
+
+# Add XCTests to generated xcconfigs
+post_install do
+  pop_test_xcconfigs = [
+    "./Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.debug.xcconfig",
+    "./Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.gcov.xcconfig",
+    "./Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.profile.xcconfig",
+    "./Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.release.xcconfig",
+    "./Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.debug.xcconfig",
+    "./Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.gcov.xcconfig",
+    "./Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.profile.xcconfig",
+    "./Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.release.xcconfig",
+  ]
+
+  pop_test_xcconfigs.each do |pop_test_xcconfig|
+    new_xcconfig = File.read(pop_test_xcconfig).gsub(/OTHER_LDFLAGS/, "POD_OTHER_LDFLAGS")
+    new_xcconfig << "\nOTHER_LDFLAGS = $(POD_OTHER_LDFLAGS) -framework XCTest"
+    new_xcconfig << "\nFRAMEWORK_SEARCH_PATHS = $(inherited) \"$(PLATFORM_DIR)/Developer/Library/Frameworks\""
+    File.write(pop_test_xcconfig, new_xcconfig)
+  end
+
+end

--- a/pop-tests/POPAnimatablePropertyTests.mm
+++ b/pop-tests/POPAnimatablePropertyTests.mm
@@ -7,8 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <pop/POPAnimatableProperty.h>
 
@@ -20,11 +19,11 @@ static void assertPropertyEqual(id self, POPAnimatableProperty *prop1, POPAnimat
   for (NSString *property in properties) {
     id value = [prop1 valueForKey:property];
     id valueCopy = [prop2 valueForKey:property];
-    STAssertEqualObjects(value, valueCopy, @"unexpected inequality; value:%@ copy:%@", value, valueCopy);
+    XCTAssertEqualObjects(value, valueCopy, @"unexpected inequality; value:%@ copy:%@", value, valueCopy);
   }
 }
 
-@interface POPAnimatablePropertyTests : SenTestCase
+@interface POPAnimatablePropertyTests : XCTestCase
 @end
 
 @implementation POPAnimatablePropertyTests
@@ -74,7 +73,7 @@ static void assertPropertyEqual(id self, POPAnimatableProperty *prop1, POPAnimat
 
   for (NSString *name in names) {
     POPAnimatableProperty *prop = [POPAnimatableProperty propertyWithName:name];
-    STAssertNotNil(prop, @"animatable property %@ should exist", name);
+    XCTAssertNotNil(prop, @"animatable property %@ should exist", name);
   }
 }
 
@@ -85,23 +84,23 @@ static void assertPropertyEqual(id self, POPAnimatableProperty *prop1, POPAnimat
   POPAnimatableProperty *prop;
 
   prop = [POPAnimatableProperty propertyWithName:name];
-  STAssertNil(prop, @"animatable property %@ should not exist", name);
+  XCTAssertNil(prop, @"animatable property %@ should not exist", name);
 
   prop = [POPAnimatableProperty propertyWithName:name initializer:^(POPMutableAnimatableProperty *p){
     p.threshold = threshold;
   }];
-  STAssertNotNil(prop, @"animatable property %@ should exist", name);
-  STAssertEqualsWithAccuracy(threshold, prop.threshold, epsilon, @"property threshold %f should equal %f", prop.threshold, threshold);
+  XCTAssertNotNil(prop, @"animatable property %@ should exist", name);
+  XCTAssertEqualWithAccuracy(threshold, prop.threshold, epsilon, @"property threshold %f should equal %f", prop.threshold, threshold);
 }
 
 - (void)testClassCluster
 {
   POPAnimatableProperty *instance1 = [[POPAnimatableProperty alloc] init];
   POPAnimatableProperty *instance2 = [[POPAnimatableProperty alloc] init];
-  STAssertTrue(instance1 == instance2, @"instance1:%@ instance2:%@", instance1, instance2);
+  XCTAssertTrue(instance1 == instance2, @"instance1:%@ instance2:%@", instance1, instance2);
 
   for (NSString *property in properties) {
-    STAssertNoThrow([instance1 valueForKey:property], @"exception on %@", property);
+    XCTAssertNoThrow([instance1 valueForKey:property], @"exception on %@", property);
   }
 }
 

--- a/pop-tests/POPAnimationMRRTests.mm
+++ b/pop-tests/POPAnimationMRRTests.mm
@@ -11,15 +11,14 @@
 
 #import <OCMock/OCMock.h>
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <pop/POP.h>
 #import <pop/POPAnimatorPrivate.h>
 
 #import "POPAnimationTestsExtras.h"
 
-@interface POPAnimationMRRTests : SenTestCase
+@interface POPAnimationMRRTests : XCTestCase
 {
   POPAnimator *_animator;
   CFTimeInterval _beginTime;
@@ -50,10 +49,10 @@
   @autoreleasepool {
     id delegate = [OCMockObject niceMockForProtocol:@protocol(POPAnimationDelegate)];
     anim.delegate = delegate;
-    STAssertNotNil(anim.delegate, @"delegate should not be nil");
+    XCTAssertNotNil(anim.delegate, @"delegate should not be nil");
   }
 
-  STAssertNil(anim.delegate, @"delegate should be nil");
+  XCTAssertNil(anim.delegate, @"delegate should be nil");
 }
 
 - (void)testAnimationCancellationOnAnimatableDeallocation

--- a/pop-tests/POPAnimationTests.mm
+++ b/pop-tests/POPAnimationTests.mm
@@ -11,8 +11,7 @@
 
 #import <OCMock/OCMock.h>
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <pop/POP.h>
 #import <pop/POPAnimationPrivate.h>
@@ -42,15 +41,15 @@ using namespace POP;
 
 - (void)testOrneryAbstractClasses
 {
-  STAssertThrows([[POPAnimation alloc] init], @"should not be able to instiate abstract class");
-  STAssertThrows([[POPPropertyAnimation alloc] init], @"should not be able to instiate abstract class");
+  XCTAssertThrows([[POPAnimation alloc] init], @"should not be able to instiate abstract class");
+  XCTAssertThrows([[POPPropertyAnimation alloc] init], @"should not be able to instiate abstract class");
 }
 
 - (void)testWithPropertyNamedConstruction
 {
   POPSpringAnimation *anim = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerBounds];
   POPAnimatableProperty *prop = [POPAnimatableProperty propertyWithName:kPOPLayerBounds];
-  STAssertTrue(anim.property == prop, @"expected:%@ actual:%@", prop, anim.property);
+  XCTAssertTrue(anim.property == prop, @"expected:%@ actual:%@", prop, anim.property);
 }
 
 - (void)testAdditionRemoval
@@ -64,22 +63,22 @@ using namespace POP;
   [layer1 pop_addAnimation:anim forKey:@"hello"];
 
   NSArray *keys = [layer1 pop_animationKeys];
-  STAssertTrue(1 == keys.count, nil);
-  STAssertTrue([@"hello" isEqualToString:keys.lastObject], nil);
+  XCTAssertTrue(1 == keys.count);
+  XCTAssertTrue([@"hello" isEqualToString:keys.lastObject]);
 
   [layer1 pop_removeAnimationForKey:@"hello"];
-  STAssertTrue(0 == [layer1 pop_animationKeys].count, nil);
+  XCTAssertTrue(0 == [layer1 pop_animationKeys].count);
 
   [layer1 pop_addAnimation:FBTestLinearPositionAnimation(self.beginTime) forKey:@"hello"];
   [layer1 pop_addAnimation:FBTestLinearPositionAnimation(self.beginTime) forKey:@"world"];
   [layer2 pop_addAnimation:FBTestLinearPositionAnimation(self.beginTime) forKey:@"hello"];
 
-  STAssertTrue(2 == [layer1 pop_animationKeys].count, nil);
-  STAssertTrue(1 == [layer2 pop_animationKeys].count, nil);
+  XCTAssertTrue(2 == [layer1 pop_animationKeys].count);
+  XCTAssertTrue(1 == [layer2 pop_animationKeys].count);
 
   [layer1 pop_removeAllAnimations];
-  STAssertTrue(0 == [layer1 pop_animationKeys].count, nil);
-  STAssertTrue(1 == [layer2 pop_animationKeys].count, nil);
+  XCTAssertTrue(0 == [layer1 pop_animationKeys].count);
+  XCTAssertTrue(1 == [layer2 pop_animationKeys].count);
 }
 
 - (void)testStartStopDelegation
@@ -136,7 +135,7 @@ using namespace POP;
   [layer1 pop_addAnimation:anim forKey:@"key"];
   POPAnimatorRenderDuration(self.animator, self.beginTime, 2.0, 0.25); // animate longer than needed to verify animation has stopped in the appropriate place
 
-  STAssertEqualObjects([layer1 valueForKeyPath:@"position"], originalToValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalToValue);
+  XCTAssertEqualObjects([layer1 valueForKeyPath:@"position"], originalToValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalToValue);
 }
 
 - (void)testNoAutoreverseRepeatCount1
@@ -154,7 +153,7 @@ using namespace POP;
   [layer1 pop_addAnimation:anim forKey:@"key"];
   POPAnimatorRenderDuration(self.animator, self.beginTime, 3.0, 0.25); // animate longer than needed to verify animation has stopped in the appropriate place
 
-  STAssertEqualObjects([layer1 valueForKeyPath:@"position"], originalToValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalToValue);
+  XCTAssertEqualObjects([layer1 valueForKeyPath:@"position"], originalToValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalToValue);
 }
 
 - (void)testNoAutoreverseRepeatCount4
@@ -172,7 +171,7 @@ using namespace POP;
   [layer1 pop_addAnimation:anim forKey:@"key"];
   POPAnimatorRenderDuration(self.animator, self.beginTime, 6.0, 0.25); // animate longer than needed to verify animation has stopped in the appropriate place
 
-  STAssertEqualObjects([layer1 valueForKeyPath:@"position"], originalToValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalToValue);
+  XCTAssertEqualObjects([layer1 valueForKeyPath:@"position"], originalToValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalToValue);
 }
 
 - (void)testAutoreverseRepeatCount0
@@ -191,10 +190,10 @@ using namespace POP;
   [layer1 pop_addAnimation:anim forKey:@"key"];
   POPAnimatorRenderDuration(self.animator, self.beginTime, 3.0, 0.25); // animate longer than needed to verify animation has stopped in the appropriate place
 
-  STAssertEqualObjects([layer1 valueForKey:@"position"], originalFromValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalFromValue);
+  XCTAssertEqualObjects([layer1 valueForKey:@"position"], originalFromValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalFromValue);
 
   NSArray *autoreversedEvents = [anim.tracer eventsWithType:kPOPAnimationEventAutoreversed];
-  STAssertTrue(1 == autoreversedEvents.count, @"unexpected autoreversed events %@", autoreversedEvents);
+  XCTAssertTrue(1 == autoreversedEvents.count, @"unexpected autoreversed events %@", autoreversedEvents);
 
   anim.autoreverses = NO;
 }
@@ -215,10 +214,10 @@ using namespace POP;
   [layer1 pop_addAnimation:anim forKey:@"key"];
   POPAnimatorRenderDuration(self.animator, self.beginTime, 3.0, 0.25); // animate longer than needed to verify animation has stopped in the appropriate place
 
-  STAssertEqualObjects([layer1 valueForKey:@"position"], originalFromValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalFromValue);
+  XCTAssertEqualObjects([layer1 valueForKey:@"position"], originalFromValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalFromValue);
 
   NSArray *autoreversedEvents = [anim.tracer eventsWithType:kPOPAnimationEventAutoreversed];
-  STAssertTrue(1 == autoreversedEvents.count, @"unexpected autoreversed events %@", autoreversedEvents);
+  XCTAssertTrue(1 == autoreversedEvents.count, @"unexpected autoreversed events %@", autoreversedEvents);
 
   anim.autoreverses = NO;
 }
@@ -241,10 +240,10 @@ using namespace POP;
   [layer1 pop_addAnimation:anim forKey:@"key"];
   POPAnimatorRenderDuration(self.animator, self.beginTime, 9.0, 0.25); // animate longer than needed to verify animation has stopped in the appropriate place
 
-  STAssertEqualObjects([layer1 valueForKey:@"position"], originalFromValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalFromValue);
+  XCTAssertEqualObjects([layer1 valueForKey:@"position"], originalFromValue, @"expected equality; value1:%@ value2:%@", [layer1 valueForKey:@"position"], originalFromValue);
 
   NSArray *autoreversedEvents = [anim.tracer eventsWithType:kPOPAnimationEventAutoreversed];
-  STAssertTrue((repeatCount * 2) - 1 == (int)autoreversedEvents.count, @"unexpected autoreversed events %@", autoreversedEvents);
+  XCTAssertTrue((repeatCount * 2) - 1 == (int)autoreversedEvents.count, @"unexpected autoreversed events %@", autoreversedEvents);
 
   anim.autoreverses = NO;
 }
@@ -440,32 +439,32 @@ using namespace POP;
 
   NSArray *didStartEvents = [anim.tracer eventsWithType:kPOPAnimationEventDidStart];
   NSArray *didStopEvents = [anim.tracer eventsWithType:kPOPAnimationEventDidStop];
-  STAssertTrue(1 == didStartEvents.count, @"unexpected start events %@", didStartEvents);
-  STAssertTrue(1 == didStopEvents.count, @"unexpected stop events %@", didStopEvents);
+  XCTAssertTrue(1 == didStartEvents.count, @"unexpected start events %@", didStartEvents);
+  XCTAssertTrue(1 == didStopEvents.count, @"unexpected stop events %@", didStopEvents);
 }
 
 - (void)testAddedKeys
 {
   POPAnimation *anim = FBTestLinearPositionAnimation();
   anim.sampleKey = @"value";
-  STAssertEqualObjects(anim.sampleKey, @"value", @"property value read should equal write");
+  XCTAssertEqualObjects(anim.sampleKey, @"value", @"property value read should equal write");
 }
 
 - (void)testValueTypeResolution
 {
   POPSpringAnimation *anim = [POPSpringAnimation animation];
-  STAssertNil(anim.fromValue, nil);
-  STAssertNil(anim.toValue, nil);
-  STAssertNil(anim.velocity, nil);
+  XCTAssertNil(anim.fromValue);
+  XCTAssertNil(anim.toValue);
+  XCTAssertNil(anim.velocity);
 
   id pointValue = [NSValue valueWithCGPoint:CGPointMake(1, 2)];
   anim.fromValue = pointValue;
   anim.toValue = pointValue;
   anim.velocity = pointValue;
 
-  STAssertEqualObjects(anim.fromValue, pointValue, @"property value read should equal write");
-  STAssertEqualObjects(anim.toValue, pointValue, @"property value read should equal write");
-  STAssertEqualObjects(anim.velocity, pointValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim.fromValue, pointValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim.toValue, pointValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim.velocity, pointValue, @"property value read should equal write");
 
   POPSpringAnimation *anim2 = [POPSpringAnimation animation];
 
@@ -474,9 +473,9 @@ using namespace POP;
   anim2.toValue = rectValue;
   anim2.velocity = rectValue;
   
-  STAssertEqualObjects(anim2.fromValue, rectValue, @"property value read should equal write");
-  STAssertEqualObjects(anim2.toValue, rectValue, @"property value read should equal write");
-  STAssertEqualObjects(anim2.velocity, rectValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim2.fromValue, rectValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim2.toValue, rectValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim2.velocity, rectValue, @"property value read should equal write");
 
 #if TARGET_OS_IPHONE
 
@@ -487,15 +486,15 @@ using namespace POP;
   anim3.toValue = edgeInsetsValue;
   anim3.velocity = edgeInsetsValue;
 
-  STAssertEqualObjects(anim3.fromValue, edgeInsetsValue, @"property value read should equal write");
-  STAssertEqualObjects(anim3.toValue, edgeInsetsValue, @"property value read should equal write");
-  STAssertEqualObjects(anim3.velocity, edgeInsetsValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim3.fromValue, edgeInsetsValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim3.toValue, edgeInsetsValue, @"property value read should equal write");
+  XCTAssertEqualObjects(anim3.velocity, edgeInsetsValue, @"property value read should equal write");
 
 #endif
 
   POPSpringAnimation *anim4 = [POPSpringAnimation animation];
   id transformValue = [NSValue valueWithCATransform3D:CATransform3DIdentity];
-  STAssertThrows(anim4.fromValue = transformValue, @"should not be able to set %@", transformValue);
+  XCTAssertThrows(anim4.fromValue = transformValue, @"should not be able to set %@", transformValue);
 }
 
 - (void)testTracer
@@ -503,7 +502,7 @@ using namespace POP;
   POPAnimatable *circle = [POPAnimatable new];
   POPSpringAnimation *anim = [POPSpringAnimation animation];
   POPAnimationTracer *tracer = anim.tracer;
-  STAssertNotNil(tracer, @"missing tracer");
+  XCTAssertNotNil(tracer, @"missing tracer");
   [tracer start];
 
   NSNumber *animFromValue = @0.0;
@@ -544,71 +543,71 @@ using namespace POP;
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
 
   // all events
-  STAssertTrue(0 != allEvents.count, @"unexpected allEvents count %@", allEvents);
+  XCTAssertTrue(0 != allEvents.count, @"unexpected allEvents count %@", allEvents);
 
   // from events
-  STAssertTrue(1 == fromEvents.count, @"unexpected fromEvents count %@", fromEvents);
+  XCTAssertTrue(1 == fromEvents.count, @"unexpected fromEvents count %@", fromEvents);
   id eventFromValue = [(POPAnimationValueEvent *)fromEvents.lastObject value];
-  STAssertEqualObjects(animFromValue, eventFromValue, @"unexpected eventFromValue; expected:%@ actual:%@", animFromValue, eventFromValue);
+  XCTAssertEqualObjects(animFromValue, eventFromValue, @"unexpected eventFromValue; expected:%@ actual:%@", animFromValue, eventFromValue);
 
   // to events
-  STAssertTrue(1 == toEvents.count, @"unexpected toEvents count %@", toEvents);
+  XCTAssertTrue(1 == toEvents.count, @"unexpected toEvents count %@", toEvents);
   id eventToValue = [(POPAnimationValueEvent *)toEvents.lastObject value];
-  STAssertEqualObjects(animToValue, eventToValue, @"unexpected eventToValue; expected:%@ actual:%@", animToValue, eventToValue);
+  XCTAssertEqualObjects(animToValue, eventToValue, @"unexpected eventToValue; expected:%@ actual:%@", animToValue, eventToValue);
 
   // velocity events
-  STAssertTrue(1 == velocityEvents.count, @"unexpected velocityEvents count %@", velocityEvents);
+  XCTAssertTrue(1 == velocityEvents.count, @"unexpected velocityEvents count %@", velocityEvents);
   id eventVelocity = [(POPAnimationValueEvent *)velocityEvents.lastObject value];
-  STAssertEqualObjects(animVelocity, eventVelocity, @"unexpected eventVelocity; expected:%@ actual:%@", animVelocity, eventVelocity);
+  XCTAssertEqualObjects(animVelocity, eventVelocity, @"unexpected eventVelocity; expected:%@ actual:%@", animVelocity, eventVelocity);
 
   // bounciness events
-  STAssertTrue(1 == bouncinessEvents.count, @"unexpected bouncinessEvents count %@", bouncinessEvents);
+  XCTAssertTrue(1 == bouncinessEvents.count, @"unexpected bouncinessEvents count %@", bouncinessEvents);
   id eventBounciness = [(POPAnimationValueEvent *)bouncinessEvents.lastObject value];
-  STAssertEqualObjects(@(animBounciness), eventBounciness, @"unexpected bounciness; expected:%@ actual:%@", @(animBounciness), eventBounciness);
+  XCTAssertEqualObjects(@(animBounciness), eventBounciness, @"unexpected bounciness; expected:%@ actual:%@", @(animBounciness), eventBounciness);
 
   // speed events
-  STAssertTrue(1 == speedEvents.count, @"unexpected speedEvents count %@", speedEvents);
+  XCTAssertTrue(1 == speedEvents.count, @"unexpected speedEvents count %@", speedEvents);
   id eventSpeed = [(POPAnimationValueEvent *)speedEvents.lastObject value];
-  STAssertEqualObjects(@(animSpeed), eventSpeed, @"unexpected speed; expected:%@ actual:%@", @(animSpeed), eventSpeed);
+  XCTAssertEqualObjects(@(animSpeed), eventSpeed, @"unexpected speed; expected:%@ actual:%@", @(animSpeed), eventSpeed);
 
   // friction events
-  STAssertTrue(1 == frictionEvents.count, @"unexpected frictionEvents count %@", frictionEvents);
+  XCTAssertTrue(1 == frictionEvents.count, @"unexpected frictionEvents count %@", frictionEvents);
   id eventFriction = [(POPAnimationValueEvent *)frictionEvents.lastObject value];
-  STAssertEqualObjects(@(animFriction), eventFriction, @"unexpected friction; expected:%@ actual:%@", @(animFriction), eventFriction);
+  XCTAssertEqualObjects(@(animFriction), eventFriction, @"unexpected friction; expected:%@ actual:%@", @(animFriction), eventFriction);
 
   // mass events
-  STAssertTrue(1 == massEvents.count, @"unexpected massEvents count %@", massEvents);
+  XCTAssertTrue(1 == massEvents.count, @"unexpected massEvents count %@", massEvents);
   id eventMass = [(POPAnimationValueEvent *)massEvents.lastObject value];
-  STAssertEqualObjects(@(animMass), eventMass, @"unexpected mass; expected:%@ actual:%@", @(animMass), eventMass);
+  XCTAssertEqualObjects(@(animMass), eventMass, @"unexpected mass; expected:%@ actual:%@", @(animMass), eventMass);
 
   // tension events
-  STAssertTrue(1 == tensionEvents.count, @"unexpected tensionEvents count %@", tensionEvents);
+  XCTAssertTrue(1 == tensionEvents.count, @"unexpected tensionEvents count %@", tensionEvents);
   id eventTension = [(POPAnimationValueEvent *)tensionEvents.lastObject value];
-  STAssertEqualObjects(@(animTension), eventTension, @"unexpected tension; expected:%@ actual:%@", @(animTension), eventTension);
+  XCTAssertEqualObjects(@(animTension), eventTension, @"unexpected tension; expected:%@ actual:%@", @(animTension), eventTension);
 
   // start & stop event
-  STAssertTrue(1 == startEvents.count, @"unexpected startEvents count %@", startEvents);
-  STAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
+  XCTAssertTrue(1 == startEvents.count, @"unexpected startEvents count %@", startEvents);
+  XCTAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
 
   // start before stop
   NSUInteger startIdx = [allEvents indexOfObjectIdenticalTo:startEvents.firstObject];
   NSUInteger stopIdx = [allEvents indexOfObjectIdenticalTo:stopEvents.firstObject];
-  STAssertTrue(startIdx < stopIdx, @"unexpected start/stop ordering startIdx:%d stopIdx:%d", startIdx, stopIdx);
+  XCTAssertTrue(startIdx < stopIdx, @"unexpected start/stop ordering startIdx:%lu stopIdx:%lu", (unsigned long)startIdx, (unsigned long)stopIdx);
 
   // did reach event
-  STAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
+  XCTAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
 
   // did reach after start before stop
   NSUInteger didReachIdx = [allEvents indexOfObjectIdenticalTo:didReachEvents.firstObject];
-  STAssertTrue(didReachIdx > startIdx, @"unexpected didReach/start ordering didReachIdx:%d startIdx:%d", didReachIdx, startIdx);
-  STAssertTrue(didReachIdx < stopIdx, @"unexpected didReach/stop ordering didReachIdx:%d stopIdx:%d", didReachIdx, stopIdx);
+  XCTAssertTrue(didReachIdx > startIdx, @"unexpected didReach/start ordering didReachIdx:%lu startIdx:%lu", (unsigned long)didReachIdx, (unsigned long)startIdx);
+  XCTAssertTrue(didReachIdx < stopIdx, @"unexpected didReach/stop ordering didReachIdx:%lu stopIdx:%lu", (unsigned long)didReachIdx, (unsigned long)stopIdx);
 
   // write events
-  STAssertTrue(0 != writeEvents.count, @"unexpected writeEvents count %@", writeEvents);
+  XCTAssertTrue(0 != writeEvents.count, @"unexpected writeEvents count %@", writeEvents);
   id firstWriteValue = [(POPAnimationValueEvent *)writeEvents.firstObject value];
-  STAssertTrue(NSOrderedSame == [anim.fromValue compare:firstWriteValue], @"unexpected firstWriteValue; fromValue:%@ actual:%@", anim.fromValue, firstWriteValue);
+  XCTAssertTrue(NSOrderedSame == [anim.fromValue compare:firstWriteValue], @"unexpected firstWriteValue; fromValue:%@ actual:%@", anim.fromValue, firstWriteValue);
   id lastWriteValue = [(POPAnimationValueEvent *)writeEvents.lastObject value];
-  STAssertEqualObjects(lastWriteValue, anim.toValue, @"unexpected lastWriteValue; expected:%@ actual:%@", anim.toValue, lastWriteValue);
+  XCTAssertEqualObjects(lastWriteValue, anim.toValue, @"unexpected lastWriteValue; expected:%@ actual:%@", anim.toValue, lastWriteValue);
 }
 
 - (void)testAnimationContinuation
@@ -631,8 +630,8 @@ using namespace POP;
   NSArray *stopEvents = [tracer eventsWithType:kPOPAnimationEventDidStop];
 
   // assert did reach but not stop
-  STAssertTrue(1 == didReachToEvents.count, @"unexpected didReachToEvents count %@", didReachToEvents);
-  STAssertTrue(0 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
+  XCTAssertTrue(1 == didReachToEvents.count, @"unexpected didReachToEvents count %@", didReachToEvents);
+  XCTAssertTrue(0 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
 
   // update to value continuing animation
   anim.toValue = @0.0;
@@ -641,20 +640,20 @@ using namespace POP;
 
   // two did reach to events
   didReachToEvents = [tracer eventsWithType:kPOPAnimationEventDidReachToValue];
-  STAssertTrue(2 == didReachToEvents.count, @"unexpected didReachToEvents count %@", didReachToEvents);
+  XCTAssertTrue(2 == didReachToEvents.count, @"unexpected didReachToEvents count %@", didReachToEvents);
 
   // first event value > animation to value
   id firstDidReachValue = [(POPAnimationValueEvent *)didReachToEvents.firstObject value];
-  STAssertTrue(NSOrderedAscending == [anim.toValue compare:firstDidReachValue], @"unexpected firstDidReachValue; toValue:%@ actual:%@", anim.toValue, firstDidReachValue);
+  XCTAssertTrue(NSOrderedAscending == [anim.toValue compare:firstDidReachValue], @"unexpected firstDidReachValue; toValue:%@ actual:%@", anim.toValue, firstDidReachValue);
 
   // second event value < animation to value
   id lastDidReachValue = [(POPAnimationValueEvent *)didReachToEvents.lastObject value];
-  STAssertTrue(NSOrderedDescending == [anim.toValue compare:lastDidReachValue], @"unexpected lastDidReachValue; toValue:%@ actual:%@", anim.toValue, lastDidReachValue);
+  XCTAssertTrue(NSOrderedDescending == [anim.toValue compare:lastDidReachValue], @"unexpected lastDidReachValue; toValue:%@ actual:%@", anim.toValue, lastDidReachValue);
 
   // did stop event
   stopEvents = [tracer eventsWithType:kPOPAnimationEventDidStop];
-  STAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
-  STAssertEqualObjects([(POPAnimationValueEvent *)stopEvents.lastObject value], @YES, @"unexpected stop event: %@", stopEvents.lastObject);
+  XCTAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
+  XCTAssertEqualObjects([(POPAnimationValueEvent *)stopEvents.lastObject value], @YES, @"unexpected stop event: %@", stopEvents.lastObject);
 }
 
 - (void)testRoundingFactor
@@ -681,7 +680,7 @@ using namespace POP;
 
     NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
     BOOL containValue = POPAnimationEventsContainValue(writeEvents, @0.5);
-    STAssertFalse(containValue, @"unexpected write value %@", writeEvents);
+    XCTAssertFalse(containValue, @"unexpected write value %@", writeEvents);
 
     if (!additive) {
       additive = YES;
@@ -708,7 +707,7 @@ using namespace POP;
 
     NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
     BOOL containValue = POPAnimationEventsContainValue(writeEvents, @0.5);
-    STAssertTrue(containValue, @"unexpected write value %@", writeEvents);
+    XCTAssertTrue(containValue, @"unexpected write value %@", writeEvents);
 
     if (!additive) {
       additive = YES;
@@ -742,8 +741,8 @@ using namespace POP;
   CGFloat firstValue = [[writeEvents firstObject] floatValue];
   CGFloat lastValue = [[writeEvents lastObject] floatValue];
   
-  STAssertTrue(firstValue >= baseValue + fromValue, @"write value expected:%f actual:%f", baseValue + fromValue, firstValue);
-  STAssertTrue(lastValue == baseValue + toValue, @"write value expected:%f actual:%f", baseValue + toValue, lastValue);
+  XCTAssertTrue(firstValue >= baseValue + fromValue, @"write value expected:%f actual:%f", baseValue + fromValue, firstValue);
+  XCTAssertTrue(lastValue == baseValue + toValue, @"write value expected:%f actual:%f", baseValue + toValue, lastValue);
 }
 
 - (void)testNilKey
@@ -763,7 +762,7 @@ using namespace POP;
   [layer pop_addAnimation:anim forKey:nil];
   
   // verify attempting to remove nil key is a noop, same as CA
-  STAssertNoThrow([layer pop_removeAnimationForKey:nil], @"unexpected exception");
+  XCTAssertNoThrow([layer pop_removeAnimationForKey:nil], @"unexpected exception");
 
   POPAnimatorRenderDuration(self.animator, self.beginTime, 1, 0.25);
   [layer verify];
@@ -778,43 +777,43 @@ using namespace POP;
 
   // literal
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   // integer
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   // short
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   // unsigned short
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   // int
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   // unsigned int
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   // long
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   // unsigned long
   anim = [POPBasicAnimation animationWithPropertyNamed:kPOPLayerOpacity];
-  STAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
-  STAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
+  XCTAssertNoThrow(anim.toValue = @(toValue), @"unexpected exception");
+  XCTAssertEqualObjects(anim.toValue, boxedToValue, @"expected equality; value1:%@ value2:%@", anim.toValue, boxedToValue);
 
   anim.fromValue = @0;
   POPAnimationTracer *tracer = anim.tracer;
@@ -827,14 +826,14 @@ using namespace POP;
 
   // verify writes happened
   NSArray *writeEvents = tracer.writeEvents;
-  STAssertTrue(writeEvents.count == 5, @"unexpected events:%@", writeEvents);
+  XCTAssertTrue(writeEvents.count == 5, @"unexpected events:%@", writeEvents);
 
   // verify initial value
   POPAnimationValueEvent *firstWriteEvent = writeEvents.firstObject;
-  STAssertTrue([firstWriteEvent.value isEqual:anim.fromValue], @"expected equality; value1:%@ value%@", firstWriteEvent.value, anim.fromValue);
+  XCTAssertTrue([firstWriteEvent.value isEqual:anim.fromValue], @"expected equality; value1:%@ value%@", firstWriteEvent.value, anim.fromValue);
 
   // verify final value
-  STAssertEqualObjects([layer valueForKey:@"opacity"], anim.toValue, @"expected equality; value1:%@ value2:%@", [layer valueForKey:@"opacity"], anim.toValue);
+  XCTAssertEqualObjects([layer valueForKey:@"opacity"], anim.toValue, @"expected equality; value1:%@ value2:%@", [layer valueForKey:@"opacity"], anim.toValue);
 }
 
 - (void)testPlatformColorSupport
@@ -842,11 +841,11 @@ using namespace POP;
   POPSpringAnimation *anim = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerBackgroundColor];
 
 #if TARGET_OS_IPHONE
-  STAssertNoThrow(anim.fromValue = [UIColor whiteColor], @"unexpected exception");
-  STAssertNoThrow(anim.toValue = [UIColor redColor], @"unexpected exception");
+  XCTAssertNoThrow(anim.fromValue = [UIColor whiteColor], @"unexpected exception");
+  XCTAssertNoThrow(anim.toValue = [UIColor redColor], @"unexpected exception");
 #else
-  STAssertNoThrow(anim.fromValue = [NSColor whiteColor], @"unexpected exception");
-  STAssertNoThrow(anim.toValue = [NSColor redColor], @"unexpected exception");
+  XCTAssertNoThrow(anim.fromValue = [NSColor whiteColor], @"unexpected exception");
+  XCTAssertNoThrow(anim.toValue = [NSColor redColor], @"unexpected exception");
 #endif
   
   POPAnimationTracer *tracer = anim.tracer;
@@ -858,7 +857,7 @@ using namespace POP;
 
   // expect some interpolation
   NSArray *writeEvents = tracer.writeEvents;
-  STAssertTrue(writeEvents.count > 1, @"unexpected write events %@", writeEvents);
+  XCTAssertTrue(writeEvents.count > 1, @"unexpected write events %@", writeEvents);
 
   // get layer color components
   CGFloat layerValues[4];
@@ -869,7 +868,7 @@ using namespace POP;
   POPCGColorGetRGBAComponents((__bridge CGColorRef)anim.toValue, toValues);
 
   // assert equality
-  STAssertTrue(layerValues[0] == toValues[0] && layerValues[1] == toValues[1] && layerValues[2] == toValues[2] && layerValues[3] == toValues[3], @"unexpected last color: [r:%f g:%f b:%f a:%f]", layerValues[0], layerValues[1], layerValues[2], layerValues[3]);
+  XCTAssertTrue(layerValues[0] == toValues[0] && layerValues[1] == toValues[1] && layerValues[2] == toValues[2] && layerValues[3] == toValues[3], @"unexpected last color: [r:%f g:%f b:%f a:%f]", layerValues[0], layerValues[1], layerValues[2], layerValues[3]);
 }
 
 @end

--- a/pop-tests/POPBaseAnimationTests.h
+++ b/pop-tests/POPBaseAnimationTests.h
@@ -7,15 +7,14 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import "POPCGUtils.h"
 
 @class CALayer;
 @class POPAnimator;
 @class POPAnimatableProperty;
 
-@interface POPBaseAnimationTests : SenTestCase
+@interface POPBaseAnimationTests : XCTestCase
 
 // two layers for test use
 @property (strong, nonatomic) CALayer *layer1, *layer2;
@@ -49,5 +48,5 @@ extern BOOL POPAnimationEventsContainValue(NSArray *events, NSNumber *value);
   CGFloat v1[4], v2[4]; \
   POPCGColorGetRGBAComponents(c1, v1); \
   POPCGColorGetRGBAComponents(c2, v2); \
-  STAssertTrue(_EQLF_(v1[0], v2[0], 1e-6) && _EQLF_(v1[1], v2[1], 1e-6) && _EQLF_(v1[2], v2[2], 1e-6) && _EQLF_(v1[3], v2[3], 1e-6), @"not equal color:[r:%f g:%f b:%f a:%f] color:[r:%f g:%f b:%f a:%f]", v1[0], v1[1], v1[2], v1[3], v2[0], v2[1], v2[2], v2[3]); \
+  XCTAssertTrue(_EQLF_(v1[0], v2[0], 1e-6) && _EQLF_(v1[1], v2[1], 1e-6) && _EQLF_(v1[2], v2[2], 1e-6) && _EQLF_(v1[3], v2[3], 1e-6), @"not equal color:[r:%f g:%f b:%f a:%f] color:[r:%f g:%f b:%f a:%f]", v1[0], v1[1], v1[2], v1[3], v2[0], v2[1], v2[2], v2[3]); \
 }

--- a/pop-tests/POPBasicAnimationTests.mm
+++ b/pop-tests/POPBasicAnimationTests.mm
@@ -7,8 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 #import <pop/POPBasicAnimation.h>
@@ -42,15 +41,15 @@
 
   // verify write count
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
-  STAssertTrue(writeEvents.count > 10, @"expected more write events %@", tracer.allEvents);
+  XCTAssertTrue(writeEvents.count > 10, @"expected more write events %@", tracer.allEvents);
   
   // verify last written value is equal to animation to value
   id lastValue = [(POPAnimationValueEvent *)writeEvents.lastObject value];
-  STAssertEqualObjects(lastValue, anim.toValue, @"expected more write events %@", tracer.allEvents);
+  XCTAssertEqualObjects(lastValue, anim.toValue, @"expected more write events %@", tracer.allEvents);
   
   // verify last written value is less than previous value
   id prevLastValue = [(POPAnimationValueEvent *)writeEvents[writeEvents.count - 2] value];
-  STAssertTrue(NSOrderedDescending == [prevLastValue compare:lastValue], @"unexpected lastValue; prevLastValue:%@ events:%@", lastValue, prevLastValue, tracer.allEvents);
+  XCTAssertTrue(NSOrderedDescending == [prevLastValue compare:lastValue], @"unexpected lastValue; prevLastValue:%@ events:%@", prevLastValue, tracer.allEvents);
 }
 
 - (void)testColorInterpolation
@@ -76,7 +75,7 @@
 
   // verify write events
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
-  STAssertTrue(writeEvents.count > 5, @"expected more write events %@", tracer.allEvents);
+  XCTAssertTrue(writeEvents.count > 5, @"expected more write events %@", tracer.allEvents);
 
   // assert final value
   POPAssertColorEqual((__bridge CGColorRef)anim.toValue, layer.backgroundColor);
@@ -106,9 +105,9 @@
     
     // verify write events
     NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
-    STAssertTrue(writeEvents.count == 1, @"expected one write event %@", tracer.allEvents);
+    XCTAssertTrue(writeEvents.count == 1, @"expected one write event %@", tracer.allEvents);
     NSArray *stopEvents = [tracer eventsWithType:kPOPAnimationEventDidStop];
-    STAssertTrue(stopEvents.count == 1, @"expected one stop event %@", tracer.allEvents);
+    XCTAssertTrue(stopEvents.count == 1, @"expected one stop event %@", tracer.allEvents);
     
     // assert final value
     POPAssertColorEqual((__bridge CGColorRef)anim.toValue, layer.backgroundColor);
@@ -156,7 +155,7 @@
   UIEdgeInsets lastEdgeInsets = [lastEvent.value UIEdgeInsetsValue];
   
   // verify last insets are to insets
-  STAssertTrue(UIEdgeInsetsEqualToEdgeInsets(lastEdgeInsets, toEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(lastEdgeInsets, toEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
 }
 #endif
 

--- a/pop-tests/POPCustomAnimationTests.mm
+++ b/pop-tests/POPCustomAnimationTests.mm
@@ -7,8 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 #import <pop/POPCustomAnimation.h>
@@ -35,7 +34,7 @@ static const CGFloat epsilon = 0.0001f;
   POPCustomAnimation *anim = [POPCustomAnimation animationWithBlock:^BOOL(id target, POPCustomAnimation *animation) {
     if (0 != callbackCount) {
       // validate elapsed time
-      STAssertEqualsWithAccuracy(animation.elapsedTime, timeInterval, epsilon, @"expected elapsedTime:%f %@", timeInterval, animation);
+      XCTAssertEqualWithAccuracy(animation.elapsedTime, timeInterval, epsilon, @"expected elapsedTime:%f %@", timeInterval, animation);
     }
 
     // increment callback count
@@ -64,13 +63,13 @@ static const CGFloat epsilon = 0.0001f;
   [layer pop_addAnimation:anim forKey:key];
   
   POPAnimatorRenderDuration(self.animator, self.beginTime + 0.1, 5, 0.1);
-  STAssertTrue(callbackCount == 3, @"unexpected callbackCount:%d", callbackCount);
+  XCTAssertTrue(callbackCount == 3, @"unexpected callbackCount:%lu", (unsigned long)callbackCount);
   
   NSArray *startEvents = [tracer eventsWithType:kPOPAnimationEventDidStart];
-  STAssertTrue(1 == startEvents.count, @"unexpected startEvents count %@", startEvents);
+  XCTAssertTrue(1 == startEvents.count, @"unexpected startEvents count %@", startEvents);
   
   NSArray *stopEvents = [tracer eventsWithType:kPOPAnimationEventDidStop];
-  STAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
+  XCTAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
 
   [layer verify];
   [delegate verify];
@@ -87,10 +86,10 @@ static const CGFloat epsilon = 0.0001f;
   POPCustomAnimation *anim = [POPCustomAnimation animationWithBlock:^BOOL(id target, POPCustomAnimation *animation) {
     if (0 == callbackCount) {
       // validate elapsed time acruel
-      STAssertEqualsWithAccuracy(animation.elapsedTime, 0., epsilon, @"expected elapsedTime:%f %@", timeInterval, animation);
+      XCTAssertEqualWithAccuracy(animation.elapsedTime, 0., epsilon, @"expected elapsedTime:%f %@", timeInterval, animation);
     } else {
       // validate elapsed time acruel
-      STAssertEqualsWithAccuracy(animation.elapsedTime, timeInterval, epsilon, @"expected elapsedTime:%f %@", timeInterval, animation);
+      XCTAssertEqualWithAccuracy(animation.elapsedTime, timeInterval, epsilon, @"expected elapsedTime:%f %@", timeInterval, animation);
     }
     
     // increment callback count
@@ -123,13 +122,13 @@ static const CGFloat epsilon = 0.0001f;
   [layer pop_addAnimation:anim forKey:key];
   
   POPAnimatorRenderDuration(self.animator, self.beginTime + 0.1, 5, 0.1);
-  STAssertTrue(callbackCount == 3, @"unexpected callbackCount:%d", callbackCount);
+  XCTAssertTrue(callbackCount == 3, @"unexpected callbackCount:%lu", (unsigned long)callbackCount);
 
   NSArray *startEvents = [tracer eventsWithType:kPOPAnimationEventDidStart];
-  STAssertTrue(1 == startEvents.count, @"unexpected startEvents count %@", startEvents);
+  XCTAssertTrue(1 == startEvents.count, @"unexpected startEvents count %@", startEvents);
   
   NSArray *stopEvents = [tracer eventsWithType:kPOPAnimationEventDidStop];
-  STAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
+  XCTAssertTrue(1 == stopEvents.count, @"unexpected stopEvents count %@", stopEvents);
   
   [layer verify];
   [delegate verify];
@@ -151,19 +150,19 @@ static const CGFloat epsilon = 0.0001f;
   [layer pop_addAnimation:anim forKey:key];
   
   // verify animation & key
-  STAssertTrue(anim == [layer pop_animationForKey:key], @"expected:%@ actual:%@", anim, [layer pop_animationForKey:key]);
-  STAssertTrue([[layer pop_animationKeys] containsObject:key], @"expected:%@ actual:%@", key, [layer pop_animationKeys]);
+  XCTAssertTrue(anim == [layer pop_animationForKey:key], @"expected:%@ actual:%@", anim, [layer pop_animationForKey:key]);
+  XCTAssertTrue([[layer pop_animationKeys] containsObject:key], @"expected:%@ actual:%@", key, [layer pop_animationKeys]);
   
   POPAnimatorRenderDuration(self.animator, self.beginTime, 1, 0.1);
 
-  STAssertEqualObjects(layer, blockTarget, @"expected:%@ actual:%@", layer, blockTarget);
+  XCTAssertEqualObjects(layer, blockTarget, @"expected:%@ actual:%@", layer, blockTarget);
   
   // remove animations
   [layer pop_removeAnimationForKey:key];
 
   // verify animation & key
-  STAssertFalse(anim == [layer pop_animationForKey:key], @"expected:%@ actual:%@", nil, [layer pop_animationForKey:key]);
-  STAssertFalse([[layer pop_animationKeys] containsObject:key], @"expected:%@ actual:%@", nil, [layer pop_animationKeys]);
+  XCTAssertFalse(anim == [layer pop_animationForKey:key], @"expected:%@ actual:%@", (id)nil, [layer pop_animationForKey:key]);
+  XCTAssertFalse([[layer pop_animationKeys] containsObject:key], @"expected:%@ actual:%@", (id)nil, [layer pop_animationKeys]);
 }
 
 @end

--- a/pop-tests/POPDecayAnimationTests.mm
+++ b/pop-tests/POPDecayAnimationTests.mm
@@ -11,8 +11,7 @@
 
 #import <OCMock/OCMock.h>
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <pop/POP.h>
 #import <pop/POPAnimatorPrivate.h>
@@ -70,11 +69,11 @@ static const CGFloat epsilon = 0.0001f;
 
   // did reach to value
   POPAnimationValueEvent *didReachToEvent = [[tracer eventsWithType:kPOPAnimationEventDidReachToValue] lastObject];
-  STAssertEqualObjects(didReachToEvent.value, anim.toValue, @"unexpected did reach to event: %@ anim:%@", didReachToEvent, anim);
+  XCTAssertEqualObjects(didReachToEvent.value, anim.toValue, @"unexpected did reach to event: %@ anim:%@", didReachToEvent, anim);
 
   // finished
   POPAnimationValueEvent *stopEvent = [[tracer eventsWithType:kPOPAnimationEventDidStop] lastObject];
-  STAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
+  XCTAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
 
   // all write values monotonically increasing
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
@@ -82,14 +81,14 @@ static const CGFloat epsilon = 0.0001f;
   for (POPAnimationValueEvent *writeEvent in writeEvents) {
     if (lastWriteEvent) {
       NSComparisonResult result = [lastWriteEvent.value compare:writeEvent.value];
-      STAssertTrue(NSOrderedAscending == result || NSOrderedSame == result, @"write event values not monotonically increasing current:%@ last:%@ all:%@", writeEvent, lastWriteEvent, writeEvents);
+      XCTAssertTrue(NSOrderedAscending == result || NSOrderedSame == result, @"write event values not monotonically increasing current:%@ last:%@ all:%@", writeEvent, lastWriteEvent, writeEvents);
     }
     lastWriteEvent = writeEvent;
   }
 
   // convergence threshold
   NSUInteger toValueFrameCount = POPAnimationCountLastEventValues(writeEvents, anim.toValue, anim.property.threshold);
-  STAssertTrue(toValueFrameCount <= kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %d", toValueFrameCount);
+  XCTAssertTrue(toValueFrameCount <= kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %lu", (unsigned long)toValueFrameCount);
 }
 
 - (void)testConvergenceNegativeVelocity
@@ -107,11 +106,11 @@ static const CGFloat epsilon = 0.0001f;
 
   // did reach to value
   POPAnimationValueEvent *didReachToEvent = [[tracer eventsWithType:kPOPAnimationEventDidReachToValue] lastObject];
-  STAssertEqualObjects(didReachToEvent.value, anim.toValue, @"unexpected did reach to event: %@ anim:%@", didReachToEvent, anim);
+  XCTAssertEqualObjects(didReachToEvent.value, anim.toValue, @"unexpected did reach to event: %@ anim:%@", didReachToEvent, anim);
 
   // finished
   POPAnimationValueEvent *stopEvent = [[tracer eventsWithType:kPOPAnimationEventDidStop] lastObject];
-  STAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
+  XCTAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
 
   // all write values monotonically increasing
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
@@ -119,27 +118,27 @@ static const CGFloat epsilon = 0.0001f;
   for (POPAnimationValueEvent *writeEvent in writeEvents) {
     if (lastWriteEvent) {
       NSComparisonResult result = [lastWriteEvent.value compare:writeEvent.value];
-      STAssertTrue(NSOrderedDescending == result || NSOrderedSame == result, @"write event values not monotonically decreasing current:%@ last:%@ all:%@", writeEvent, lastWriteEvent, writeEvents);
+      XCTAssertTrue(NSOrderedDescending == result || NSOrderedSame == result, @"write event values not monotonically decreasing current:%@ last:%@ all:%@", writeEvent, lastWriteEvent, writeEvents);
     }
     lastWriteEvent = writeEvent;
   }
 
   // convergence threshold
   NSUInteger toValueFrameCount = POPAnimationCountLastEventValues(writeEvents, anim.toValue, anim.property.threshold);
-  STAssertTrue(toValueFrameCount <= kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %d", toValueFrameCount);
+  XCTAssertTrue(toValueFrameCount <= kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %lu", (unsigned long)toValueFrameCount);
 }
 
 - (void)test2DConvergence
 {
   POPDecayAnimation *animX = self._positionXAnimation;
   POPDecayAnimation *animY = self._positionYAnimation;
-  STAssertEquals(animX.duration, animY.duration, @"unexpected durations animX:%@ animY:%@", animX, animY);
-  STAssertEqualObjects(animX.toValue, animY.toValue, @"unexpected toValue animX:%@ animY:%@", animX, animY);
+  XCTAssertEqual(animX.duration, animY.duration, @"unexpected durations animX:%@ animY:%@", animX, animY);
+  XCTAssertEqualObjects(animX.toValue, animY.toValue, @"unexpected toValue animX:%@ animY:%@", animX, animY);
 
   POPDecayAnimation *anim = self._positionAnimation;
   CFTimeInterval duration = anim.duration;
-  STAssertEqualsWithAccuracy(animX.duration, duration, epsilon, @"unexpected durations animX:%@ anim:%@", animX, anim);
-  STAssertEqualObjects(animX.toValue, @([anim.toValue CGPointValue].x), @"unexpected toValue animX:%@ anim:%@", animX, anim);
+  XCTAssertEqualWithAccuracy(animX.duration, duration, epsilon, @"unexpected durations animX:%@ anim:%@", animX, anim);
+  XCTAssertEqualObjects(animX.toValue, @([anim.toValue CGPointValue].x), @"unexpected toValue animX:%@ anim:%@", animX, anim);
 
   POPAnimatable *circle = [POPAnimatable new];
   POPAnimationTracer *tracer = anim.tracer;
@@ -151,19 +150,19 @@ static const CGFloat epsilon = 0.0001f;
 
   // did reach to value
   POPAnimationValueEvent *didReachToEvent = [[tracer eventsWithType:kPOPAnimationEventDidReachToValue] lastObject];
-  STAssertEqualObjects(didReachToEvent.value, anim.toValue, @"unexpected did reach to event: %@ anim:%@", didReachToEvent, anim);
+  XCTAssertEqualObjects(didReachToEvent.value, anim.toValue, @"unexpected did reach to event: %@ anim:%@", didReachToEvent, anim);
 
   // finished
   POPAnimationValueEvent *stopEvent = [[tracer eventsWithType:kPOPAnimationEventDidStop] lastObject];
-  STAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
+  XCTAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
 
   // increase X velocity
   anim.velocity = [NSValue valueWithCGPoint:CGPointMake(7223.021 + 1000, 7223.021)];
-  STAssertTrue(anim.duration > duration, @"unexpected duration expected:%f anim:%@", duration, anim);
+  XCTAssertTrue(anim.duration > duration, @"unexpected duration expected:%f anim:%@", duration, anim);
 
   // increase Y velocity
   anim.velocity = [NSValue valueWithCGPoint:CGPointMake(7223.021, 7223.021 + 1000)];
-  STAssertTrue(anim.duration > duration, @"unexpected duration expected:%f anim:%@", duration, anim);
+  XCTAssertTrue(anim.duration > duration, @"unexpected duration expected:%f anim:%@", duration, anim);
 }
 
 - (void)testRemovedOnCompletionNoStartStopBasics
@@ -202,11 +201,11 @@ static const CGFloat epsilon = 0.0001f;
 
   // verify delegate
   [delegate verify];
-  STAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
-  STAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
+  XCTAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
+  XCTAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
 
   // assert animation has not been removed
-  STAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
+  XCTAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
 }
 
 - (void)testRemovedOnCompletionNoContinuations
@@ -261,9 +260,9 @@ static const CGFloat epsilon = 0.0001f;
 
       // verify delegate
       [delegate verify];
-      STAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
-      STAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
-      STAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
+      XCTAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
+      XCTAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
+      XCTAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
     } else if (velocities.count - 1 == idx) {
       // continue stoped animation
       [tracer reset];
@@ -280,9 +279,9 @@ static const CGFloat epsilon = 0.0001f;
 
       // verify delegate
       [delegate verify];
-      STAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
-      STAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
-      STAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
+      XCTAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
+      XCTAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
+      XCTAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
     } else {
       // continue stoped (idx = 1) or started animation
       if (1 == idx) {
@@ -303,13 +302,13 @@ static const CGFloat epsilon = 0.0001f;
 
       // verify delegate
       [delegate verify];
-      STAssertTrue(0 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
-      STAssertFalse(completionBlock, @"completion block did not execute %@ %@", anim, allEvents);
-      STAssertFalse(completionBlockFinished, @"completion block did not finish %@ %@", anim, allEvents);
+      XCTAssertTrue(0 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
+      XCTAssertFalse(completionBlock, @"completion block did not execute %@ %@", anim, allEvents);
+      XCTAssertFalse(completionBlockFinished, @"completion block did not finish %@ %@", anim, allEvents);
     }
 
     // assert animation has not been removed
-    STAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
+    XCTAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
   }];
 }
 
@@ -343,7 +342,7 @@ static const CGFloat epsilon = 0.0001f;
   // verify number values
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
   for (POPAnimationValueEvent *writeEvent in writeEvents) {
-    STAssertEqualObjects(writeEvent.value, [NSValue valueWithCGPoint:initialValue], @"unexpected write event:%@ anim:%@", writeEvent, anim);
+    XCTAssertEqualObjects(writeEvent.value, [NSValue valueWithCGPoint:initialValue], @"unexpected write event:%@ anim:%@", writeEvent, anim);
   }
 }
 
@@ -387,7 +386,7 @@ static const CGFloat epsilon = 0.0001f;
   POPAnimationValueEvent *firstEvent = [writeEvents firstObject];
   POPAnimationValueEvent *lastEvent = [writeEvents lastObject];
   POPAnimationValueEvent *firstMoreEvent = [moreWriteEvents firstObject];
-  STAssertTrue(NSOrderedAscending == [firstEvent.value compare:lastEvent.value]
+  XCTAssertTrue(NSOrderedAscending == [firstEvent.value compare:lastEvent.value]
                && NSOrderedAscending == [lastEvent.value compare:firstMoreEvent.value], @"write event values not monotonically increasing %@ %@ %@", firstEvent, lastEvent, firstMoreEvent);
 }
 
@@ -425,8 +424,8 @@ static const CGFloat epsilon = 0.0001f;
   POPAnimationValueEvent *lastEvent = [writeEvents lastObject];
   CGRect lastRect = [lastEvent.value CGRectValue];
   
-  STAssertTrue(!CGRectEqualToRect(fromRect, lastRect), @"unexpected last rect value: %@", lastEvent);
-  STAssertTrue(lastRect.origin.x == lastRect.origin.y && lastRect.size.width == lastRect.size.height && lastRect.origin.x < lastRect.size.width, @"unexpected last rect value: %@", lastEvent);
+  XCTAssertTrue(!CGRectEqualToRect(fromRect, lastRect), @"unexpected last rect value: %@", lastEvent);
+  XCTAssertTrue(lastRect.origin.x == lastRect.origin.y && lastRect.size.width == lastRect.size.height && lastRect.origin.x < lastRect.size.width, @"unexpected last rect value: %@", lastEvent);
 }
 
 #if TARGET_OS_IPHONE
@@ -465,8 +464,8 @@ static const CGFloat epsilon = 0.0001f;
   POPAnimationValueEvent *lastEvent = [writeEvents lastObject];
   UIEdgeInsets lastEdgeInsets = [lastEvent.value UIEdgeInsetsValue];
 
-  STAssertTrue(!UIEdgeInsetsEqualToEdgeInsets(fromEdgeInsets, lastEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
-  STAssertTrue(lastEdgeInsets.top == lastEdgeInsets.left && lastEdgeInsets.bottom == lastEdgeInsets.right && lastEdgeInsets.top < lastEdgeInsets.bottom, @"unexpected last edge insets value: %@", lastEvent);
+  XCTAssertTrue(!UIEdgeInsetsEqualToEdgeInsets(fromEdgeInsets, lastEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
+  XCTAssertTrue(lastEdgeInsets.top == lastEdgeInsets.left && lastEdgeInsets.bottom == lastEdgeInsets.right && lastEdgeInsets.top < lastEdgeInsets.bottom, @"unexpected last edge insets value: %@", lastEvent);
 }
 #endif
 
@@ -484,10 +483,10 @@ static const CGFloat epsilon = 0.0001f;
   POPAnimatorRenderDuration(self.animator, self.beginTime, 5.0, 1.0/60.0);
 
   NSArray *stopEvent = [tracer eventsWithType:kPOPAnimationEventDidStop];
-  STAssertTrue(1 == stopEvent.count, @"unexpected events:%@", tracer.allEvents);
+  XCTAssertTrue(1 == stopEvent.count, @"unexpected events:%@", tracer.allEvents);
 
   CGFloat lastValue = [[(POPAnimationValueEvent *)tracer.writeEvents.lastObject value] floatValue];
-  STAssertEqualsWithAccuracy(toValue, lastValue, 0.5, @"expected:%f actual event:%@", tracer.writeEvents.lastObject);
+  XCTAssertEqualWithAccuracy(toValue, lastValue, 0.5, @"expected:%f actual event:%@", lastValue, tracer.writeEvents.lastObject);
   // update animation
   anim.fromValue = @([anim.toValue floatValue] - 100);
   anim.velocity = @(5000.);
@@ -499,7 +498,7 @@ static const CGFloat epsilon = 0.0001f;
 
   // verify decayed passed initial toValue
   lastValue = [[(POPAnimationValueEvent *)tracer.writeEvents.lastObject value] floatValue];
-  STAssertTrue(lastValue > toValue, @"unexpected last value:%f");
+  XCTAssertTrue(lastValue > toValue, @"unexpected last value:%f", lastValue);
 }
 
 - (void)testComputedProperties
@@ -509,22 +508,22 @@ static const CGFloat epsilon = 0.0001f;
   // set velocity, test duration
   anim.velocity = @(100);
   CGFloat d1 = anim.duration;
-  STAssertTrue(d1 > 0, @"unexpected duration %@", anim);
+  XCTAssertTrue(d1 > 0, @"unexpected duration %@", anim);
   
   // set velocity, test duration
   anim.velocity = @(1000);
   CGFloat d2 = anim.duration;
-  STAssertTrue(d2 > d1, @"unexpected duration %@", anim);
+  XCTAssertTrue(d2 > d1, @"unexpected duration %@", anim);
 
   // set from value, test to value
   anim.fromValue = @(0);
   CGFloat p1 = [anim.toValue floatValue];
-  STAssertTrue(p1 > [anim.fromValue floatValue], @"unexpected to value %@", anim);
+  XCTAssertTrue(p1 > [anim.fromValue floatValue], @"unexpected to value %@", anim);
   
   // set from value, test to value
   anim.fromValue = @(10000);
   CGFloat p2 = [anim.toValue floatValue];
-  STAssertTrue(p2 > [anim.fromValue floatValue] && p2 > p1, @"unexpected to value %@", anim);
+  XCTAssertTrue(p2 > [anim.fromValue floatValue] && p2 > p1, @"unexpected to value %@", anim);
 }
 
 @end

--- a/pop-tests/POPEaseInEaseOutAnimationTests.mm
+++ b/pop-tests/POPEaseInEaseOutAnimationTests.mm
@@ -11,8 +11,7 @@
 
 #import <OCMock/OCMock.h>
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <pop/POP.h>
 #import <pop/POPAnimatorPrivate.h>
@@ -87,7 +86,7 @@
   CGRect lastRect = [lastEvent.value CGRectValue];
   
   // verify last rect is to rect
-  STAssertTrue(CGRectEqualToRect(lastRect, toRect), @"unexpected last rect value: %@", lastEvent);
+  XCTAssertTrue(CGRectEqualToRect(lastRect, toRect), @"unexpected last rect value: %@", lastEvent);
 }
 
 @end

--- a/pop-tests/POPSpringAnimationTests.mm
+++ b/pop-tests/POPSpringAnimationTests.mm
@@ -7,8 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#define SENTEST_IGNORE_DEPRECATION_WARNING
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 #import <QuartzCore/QuartzCore.h>
@@ -49,7 +48,7 @@ static NSString *animationKey = @"key";
   POPSpringAnimation *anim = [POPSpringAnimation animation];
   anim.property = [POPAnimatableProperty propertyWithName:kPOPLayerPosition];
   anim.progressMarkers = markers;
-  STAssertEqualObjects(markers, anim.progressMarkers, @"%@ shoudl equal %@", markers, anim.progressMarkers);
+  XCTAssertEqualObjects(markers, anim.progressMarkers, @"%@ shoudl equal %@", markers, anim.progressMarkers);
 
   // delegate
   id delegate = [OCMockObject niceMockForProtocol:@protocol(POPAnimationDelegate)];
@@ -92,12 +91,12 @@ static NSString *animationKey = @"key";
 
   // finished
   POPAnimationValueEvent *stopEvent = [[tracer eventsWithType:kPOPAnimationEventDidStop] lastObject];
-  STAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
+  XCTAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
 
   // convergence threshold
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
   NSUInteger toValueFrameCount = POPAnimationCountLastEventValues(writeEvents, anim.toValue, anim.property.threshold);
-  STAssertTrue(toValueFrameCount < kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %d", toValueFrameCount);
+  XCTAssertTrue(toValueFrameCount < kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %lu", (unsigned long)toValueFrameCount);
 }
 
 - (void)testConvergenceRounded
@@ -120,12 +119,12 @@ static NSString *animationKey = @"key";
 
   // finished
   POPAnimationValueEvent *stopEvent = [[tracer eventsWithType:kPOPAnimationEventDidStop] lastObject];
-  STAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
+  XCTAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
 
   // convergence threshold
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
   NSUInteger toValueFrameCount = POPAnimationCountLastEventValues(writeEvents, anim.toValue);
-  STAssertTrue(toValueFrameCount < kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %d", toValueFrameCount);
+  XCTAssertTrue(toValueFrameCount < kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %lu", (unsigned long)toValueFrameCount);
 }
 
 - (void)testConvergenceClampedRounded
@@ -149,12 +148,12 @@ static NSString *animationKey = @"key";
 
   // finished
   POPAnimationValueEvent *stopEvent = [[tracer eventsWithType:kPOPAnimationEventDidStop] lastObject];
-  STAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
+  XCTAssertEqualObjects(stopEvent.value, @YES, @"unexpected stop event %@", stopEvent);
 
   // convergence threshold
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
   NSUInteger toValueFrameCount = POPAnimationCountLastEventValues(writeEvents, anim.toValue);
-  STAssertTrue(toValueFrameCount < kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %d", toValueFrameCount);
+  XCTAssertTrue(toValueFrameCount < kPOPAnimationConvergenceMaxFrameCount, @"unexpected convergence; toValueFrameCount: %lu", (unsigned long)toValueFrameCount);
 }
 
 - (void)testRemovedOnCompletionNoStartStopBasics
@@ -192,11 +191,11 @@ static NSString *animationKey = @"key";
 
   // verify delegate
   [delegate verify];
-  STAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
-  STAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
+  XCTAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
+  XCTAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
 
   // assert animation has not been removed
-  STAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
+  XCTAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
 }
 
 - (void)testRemovedOnCompletionNoContinuations
@@ -251,9 +250,9 @@ static NSString *animationKey = @"key";
 
       // verify delegate
       [delegate verify];
-      STAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
-      STAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
-      STAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
+      XCTAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
+      XCTAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
+      XCTAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
     } else if (toValues.count - 1 == idx) {
       // continue stoped animation
       [tracer reset];
@@ -270,9 +269,9 @@ static NSString *animationKey = @"key";
 
       // verify delegate
       [delegate verify];
-      STAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
-      STAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
-      STAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
+      XCTAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
+      XCTAssertTrue(completionBlock, @"completion block did not execute %@", allEvents);
+      XCTAssertTrue(completionBlockFinished, @"completion block did not finish %@", allEvents);
     } else {
       // continue stoped (idx = 1) or started animation
       if (1 == idx) {
@@ -293,13 +292,13 @@ static NSString *animationKey = @"key";
 
       // verify delegate
       [delegate verify];
-      STAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
-      STAssertFalse(completionBlock, @"completion block did not execute %@ %@", anim, allEvents);
-      STAssertFalse(completionBlockFinished, @"completion block did not finish %@ %@", anim, allEvents);
+      XCTAssertTrue(1 == didReachEvents.count, @"unexpected didReachEvents %@", didReachEvents);
+      XCTAssertFalse(completionBlock, @"completion block did not execute %@ %@", anim, allEvents);
+      XCTAssertFalse(completionBlockFinished, @"completion block did not finish %@ %@", anim, allEvents);
     }
 
     // assert animation has not been removed
-    STAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
+    XCTAssertTrue(anim == [layer pop_animationForKey:animationKey], @"expected animation on layer animations:%@", [layer pop_animationKeys]);
   }];
 }
 
@@ -333,7 +332,7 @@ static NSString *animationKey = @"key";
   // verify number values
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
   for (POPAnimationValueEvent *writeEvent in writeEvents) {
-    STAssertEqualObjects(writeEvent.value, [NSValue valueWithCGPoint:initialValue], @"unexpected write event:%@ anim:%@", writeEvent, anim);
+    XCTAssertEqualObjects(writeEvent.value, [NSValue valueWithCGPoint:initialValue], @"unexpected write event:%@ anim:%@", writeEvent, anim);
   }
 }
 
@@ -353,20 +352,20 @@ static NSString *animationKey = @"key";
   // add animation, but do not start
   [layer pop_addAnimation:anim forKey:animationKey];
   POPAnimatorRenderDuration(self.animator, self.beginTime, 0.2, 1.0/60.0);
-  STAssertNotNil(anim.fromValue, @"unexpected from value %@", anim);
-  STAssertNil(anim.toValue, @"unexpected to value %@", anim);
+  XCTAssertNotNil(anim.fromValue, @"unexpected from value %@", anim);
+  XCTAssertNil(anim.toValue, @"unexpected to value %@", anim);
 
   // start animation
   POPAnimatorRenderDuration(self.animator, self.beginTime + 0.2, 0.2, 1.0/60.0);
-  STAssertNotNil(anim.fromValue, @"unexpected from value %@", anim);
-  STAssertNotNil(anim.toValue, @"unexpected to value %@", anim);
+  XCTAssertNotNil(anim.fromValue, @"unexpected from value %@", anim);
+  XCTAssertNotNil(anim.toValue, @"unexpected to value %@", anim);
 
   // continue running animation
   anim.fromValue = nil;
   anim.toValue = @200.0;
   POPAnimatorRenderDuration(self.animator, self.beginTime + 0.4, 0.2, 1.0/60.0);
-  STAssertNotNil(anim.fromValue, @"unexpected from value %@", anim);
-  STAssertNotNil(anim.toValue, @"unexpected to value %@", anim);
+  XCTAssertNotNil(anim.fromValue, @"unexpected from value %@", anim);
+  XCTAssertNotNil(anim.toValue, @"unexpected to value %@", anim);
 }
 
 - (void)testLatentSpring
@@ -418,7 +417,7 @@ static NSString *animationKey = @"key";
   CGRect lastRect = [lastEvent.value CGRectValue];
 
   // verify last rect is to rect
-  STAssertTrue(CGRectEqualToRect(lastRect, toRect), @"unexpected last rect value: %@", lastEvent);
+  XCTAssertTrue(CGRectEqualToRect(lastRect, toRect), @"unexpected last rect value: %@", lastEvent);
 }
 
 #if TARGET_OS_IPHONE
@@ -465,7 +464,7 @@ static NSString *animationKey = @"key";
   UIEdgeInsets lastEdgeInsets = [lastEvent.value UIEdgeInsetsValue];
 
   // verify last insets are to insets
-  STAssertTrue(UIEdgeInsetsEqualToEdgeInsets(lastEdgeInsets, toEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(lastEdgeInsets, toEdgeInsets), @"unexpected last edge insets value: %@", lastEvent);
 }
 #endif
 
@@ -500,7 +499,7 @@ static NSString *animationKey = @"key";
   [delegate verify];
 
   // expect some interpolation
-  STAssertTrue(writeEvents.count > 1, @"unexpected write events %@", writeEvents);
+  XCTAssertTrue(writeEvents.count > 1, @"unexpected write events %@", writeEvents);
   POPAnimationValueEvent *lastEvent = [writeEvents lastObject];
 
   // verify last written color is to color
@@ -524,7 +523,7 @@ static BOOL _floatingPointEqual(CGFloat a, CGFloat b)
   CGFloat outBounciness, outSpeed;
   [POPSpringAnimation convertTension:tension friction:friction toBounciness:&outBounciness speed:&outSpeed];
 
-  STAssertTrue(_floatingPointEqual(sampleBounciness, outBounciness) && _floatingPointEqual(sampleSpeed, outSpeed), @"(bounciness, speed) conversion failed. Mapped (%f, %f) back to (%f, %f)", sampleBounciness, sampleSpeed, outBounciness, outSpeed);
+  XCTAssertTrue(_floatingPointEqual(sampleBounciness, outBounciness) && _floatingPointEqual(sampleSpeed, outSpeed), @"(bounciness, speed) conversion failed. Mapped (%f, %f) back to (%f, %f)", sampleBounciness, sampleSpeed, outBounciness, outSpeed);
 }
 
 - (void)testTensionFrictionToBouncinessSpeedConversion
@@ -538,7 +537,7 @@ static BOOL _floatingPointEqual(CGFloat a, CGFloat b)
   CGFloat outTension, outFriction, outMass;
   [POPSpringAnimation convertBounciness:bounciness speed:speed toTension:&outTension friction:&outFriction mass:&outMass];
 
-  STAssertTrue(_floatingPointEqual(sampleTension, outTension) && _floatingPointEqual(sampleFriction, outFriction), @"(tension, friction) conversion failed. Mapped (%f, %f) back to (%f, %f)", sampleTension, sampleFriction, outTension, outFriction);
+  XCTAssertTrue(_floatingPointEqual(sampleTension, outTension) && _floatingPointEqual(sampleFriction, outFriction), @"(tension, friction) conversion failed. Mapped (%f, %f) back to (%f, %f)", sampleTension, sampleFriction, outTension, outFriction);
 }
 
 - (void)testRemovedOnCompletionNoContinuationValues
@@ -558,7 +557,7 @@ static BOOL _floatingPointEqual(CGFloat a, CGFloat b)
   POPAnimatorRenderDuration(self.animator, self.beginTime, 3, 1.0/60.0);
 
   // assert reached to value
-  STAssertTrue(layer.position.x == [anim.toValue floatValue], @"unexpected value:%@ %@", layer, anim);
+  XCTAssertTrue(layer.position.x == [anim.toValue floatValue], @"unexpected value:%@ %@", layer, anim);
 
   // start tracer
   POPAnimationTracer *tracer = anim.tracer;
@@ -570,12 +569,12 @@ static BOOL _floatingPointEqual(CGFloat a, CGFloat b)
 
   // verify from 200 to 400
   NSArray *writeEvents = [tracer eventsWithType:kPOPAnimationEventPropertyWrite];
-  STAssertTrue(writeEvents.count > 5, @"unexpected frame count %@", writeEvents);
+  XCTAssertTrue(writeEvents.count > 5, @"unexpected frame count %@", writeEvents);
 
   CGFloat firstValue = [[(POPAnimationValueEvent *)[writeEvents firstObject] value] floatValue];
   CGFloat lastValue = [[(POPAnimationValueEvent *)[writeEvents lastObject] value] floatValue];
-  STAssertEqualsWithAccuracy(((CGFloat)[toValues[0] floatValue]), firstValue, 10, @"unexpected first value %@", writeEvents);
-  STAssertEqualsWithAccuracy(((CGFloat)[toValues[1] floatValue]), lastValue, 10, @"unexpected last value %@", writeEvents);
+  XCTAssertEqualWithAccuracy(((CGFloat)[toValues[0] floatValue]), firstValue, 10, @"unexpected first value %@", writeEvents);
+  XCTAssertEqualWithAccuracy(((CGFloat)[toValues[1] floatValue]), lastValue, 10, @"unexpected last value %@", writeEvents);
 }
 
 - (void)testNilColor
@@ -600,7 +599,7 @@ static BOOL _floatingPointEqual(CGFloat a, CGFloat b)
 
   // verify valid from color exists
   CGColorRef fromColor = (__bridge CGColorRef)anim.fromValue;
-  STAssertTrue(fromColor, @"unexpected value %p", fromColor);
+  XCTAssertTrue(fromColor, @"unexpected value %p", fromColor);
 
   // verify from color clear
 #if TARGET_OS_IPHONE
@@ -637,7 +636,7 @@ static BOOL _floatingPointEqual(CGFloat a, CGFloat b)
 
   // verify last write event value
   POPAnimationValueEvent *writeEvent = [[tracer eventsWithType:kPOPAnimationEventPropertyWrite] lastObject];
-  STAssertEqualObjects(writeEvent.value, anim.toValue, @"unexpected last write event %@", writeEvent);
+  XCTAssertEqualObjects(writeEvent.value, anim.toValue, @"unexpected last write event %@", writeEvent);
 }
 
 - (void)testEquivalentFromToValues
@@ -658,7 +657,7 @@ static BOOL _floatingPointEqual(CGFloat a, CGFloat b)
 
   // verify last write event value
   POPAnimationValueEvent *writeEvent = [[tracer eventsWithType:kPOPAnimationEventPropertyWrite] lastObject];
-  STAssertEqualObjects(writeEvent.value, anim.toValue, @"unexpected last write event %@", writeEvent);
+  XCTAssertEqualObjects(writeEvent.value, anim.toValue, @"unexpected last write event %@", writeEvent);
 }
 
 @end

--- a/pop.podspec
+++ b/pop.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |spec|
        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
        'CLANG_CXX_LIBRARY' => 'libc++'
   }
-
   spec.ios.deployment_target = '6.0'
   spec.osx.deployment_target = '10.7'
 end

--- a/pop.xcodeproj/project.pbxproj
+++ b/pop.xcodeproj/project.pbxproj
@@ -1,6223 +1,2001 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>02E3EF56E92B403A9BF79E26</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>name</key>
-			<string>boost</string>
-			<key>path</key>
-			<string>../../Vendor/Boost/boost.framework/boost</string>
-			<key>sourceTree</key>
-			<string>SRCROOT</string>
-		</dict>
-		<key>063BFBF07EAD4D74B19E2BC0</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>093AEF8FEE094AECB5EDCED2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>0B6BE74319FFD3B900762101</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>0B6BE7D119FFD92700762101</string>
-				<string>0B6BE7D219FFD92700762101</string>
-				<string>0B6BE7D319FFD92700762101</string>
-				<string>0B6BE7D419FFD92700762101</string>
-				<string>0B6BE7D519FFD92700762101</string>
-				<string>0B6BE7D619FFD92700762101</string>
-				<string>0B6BE7D719FFD92700762101</string>
-				<string>0B6BE7D819FFD92700762101</string>
-				<string>0B6BE7D919FFD92700762101</string>
-				<string>0B6BE7DA19FFD92700762101</string>
-				<string>0B6BE7DB19FFD92700762101</string>
-				<string>0B6BE7DC19FFD92700762101</string>
-				<string>0B6BE7DD19FFD92700762101</string>
-				<string>0B6BE7DE19FFD92700762101</string>
-				<string>0B6BE7DF19FFD92700762101</string>
-				<string>0B6BE7E019FFD92800762101</string>
-				<string>0B6BE7E119FFD92800762101</string>
-				<string>0B6BE7D019FFD90F00762101</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0B6BE74419FFD3B900762101</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0B6BE74519FFD3B900762101</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>0B6BE77819FFD4AB00762101</string>
-				<string>0B6BE77719FFD4A300762101</string>
-				<string>0B6BE77619FFD49A00762101</string>
-				<string>0B6BE77519FFD49100762101</string>
-				<string>0B6BE77419FFD48700762101</string>
-				<string>0B6BE77319FFD47F00762101</string>
-				<string>0B6BE77219FFD47800762101</string>
-				<string>0B6BE77119FFD46F00762101</string>
-				<string>0B6BE77019FFD46600762101</string>
-				<string>0B6BE76F19FFD44000762101</string>
-				<string>0B6BE76E19FFD43800762101</string>
-				<string>0B6BE76D19FFD42700762101</string>
-				<string>0B6BE76C19FFD41D00762101</string>
-				<string>0B6BE76B19FFD41500762101</string>
-				<string>669428F71A009B6A00A420B0</string>
-				<string>0B6BE76A19FFD41100762101</string>
-				<string>0B6BE76919FFD40700762101</string>
-				<string>0B6BE76819FFD3FF00762101</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0B6BE74619FFD3B900762101</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>669428F61A009B6A00A420B0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>0B6BE74719FFD3B900762101</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>0B6BE75B19FFD3B900762101</string>
-			<key>buildPhases</key>
-			<array>
-				<string>0B6BE74319FFD3B900762101</string>
-				<string>0B6BE74419FFD3B900762101</string>
-				<string>0B6BE74519FFD3B900762101</string>
-				<string>0B6BE74619FFD3B900762101</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>pop-embedded</string>
-			<key>productName</key>
-			<string>pop-ios</string>
-			<key>productReference</key>
-			<string>0B6BE74819FFD3B900762101</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>0B6BE74819FFD3B900762101</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>pop.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>0B6BE75B19FFD3B900762101</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>0B6BE75C19FFD3B900762101</string>
-				<string>0B6BE75D19FFD3B900762101</string>
-				<string>0B6BE75E19FFD3B900762101</string>
-				<string>0B6BE75F19FFD3B900762101</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>0B6BE75C19FFD3B900762101</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>0BA2A8F219FFDC7F00B28783</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OTHER_CFLAGS</key>
-				<string></string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>0B6BE75D19FFD3B900762101</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>0BA2A8F219FFDC7F00B28783</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_CFLAGS</key>
-				<string></string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>GCOV</string>
-		</dict>
-		<key>0B6BE75E19FFD3B900762101</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>0BA2A8F219FFDC7F00B28783</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_CFLAGS</key>
-				<string></string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>0B6BE75F19FFD3B900762101</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>0BA2A8F219FFDC7F00B28783</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OTHER_CFLAGS</key>
-				<string></string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>0B6BE76819FFD3FF00762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2618EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE76919FFD40700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECA94D0B18ECAE82002E4CEB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE76A19FFD41100762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997531756A0C300A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE76B19FFD41500762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC91E95F18C00EC90025B8AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE76C19FFD41D00762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015A18FFBE8C00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE76D19FFD42700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC0AE12F16BC73CE001DA2CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE76E19FFD43800762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E17BB1E17457345009842B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE76F19FFD44000762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016618FFBEB500DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77019FFD46600762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07B17D95CAA003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77119FFD46F00762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128D162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77219FFD47800762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F013E18FFBBD300DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77319FFD47F00762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014D18FFBD3E00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77419FFD48700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128E162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77519FFD49100762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128B162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77619FFD49A00762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191288162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77719FFD4A300762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC1CD94E18D80A5C00DE2649</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE77819FFD4AB00762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECD80F0F18CFD2EF00AE4303</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0B6BE7D019FFD90F00762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07717D95447003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D119FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191289162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D219FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014A18FFBC8200DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D319FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014E18FFBD3E00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D419FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E17BB1F17457345009842B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D519FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015B18FFBE8C00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D619FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016718FFBEB500DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D719FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128F162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D819FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997541756A0C300A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7D919FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC0AE13016BC73CE001DA2CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7DA19FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC95538F1743E278001E6AF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7DB19FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2718EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7DC19FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128C162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7DD19FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC67007118D3D89F00F7387F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7DE19FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECD80F1018CFD2EF00AE4303</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7DF19FFD92700762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07C17D95CAA003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7E019FFD92800762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6465CF1794B4660014176F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7E119FFD92800762101</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC70AC4218CCF4FC0067018C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0B6BE7E619FFD98100762101</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreImage.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreImage.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>0BA2A8F119FFDC7F00B28783</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>0BA2A8F219FFDC7F00B28783</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Dynamic Libraries</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0BA2A8F219FFDC7F00B28783</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>DynamicLibrary-iOS.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2F7E04AE9A5B41869AF78DA9</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>3606F0C22CF0EB387E8AC270</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests.profile.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>394D14BF947A476EB827103B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>403DCBBC1783F4A000793AE1</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBWebP.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>408E6FF86BDD3F47FC44BF6A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests.gcov.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.gcov.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4372557D5165714123EC6D70</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4F4245BFB89B6239FE145E69</string>
-				<string>408E6FF86BDD3F47FC44BF6A</string>
-				<string>C5794B0CC3DBDE8D02CF112A</string>
-				<string>3606F0C22CF0EB387E8AC270</string>
-				<string>9BBD2916A451976950B4C1F6</string>
-				<string>7628E8427F4090DD496F92B1</string>
-				<string>7BDD7D9C2D2C9AC55E295CD0</string>
-				<string>7D469990AA7D05FB882F89FC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4F4245BFB89B6239FE145E69</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5E17BB1E17457345009842B6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPCustomAnimation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5E17BB1F17457345009842B6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPCustomAnimation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5E17BB2017457345009842B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E17BB1E17457345009842B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>5E17BB2117457345009842B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E17BB1F17457345009842B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>669428F31A009B6A00A420B0</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>669428F41A009B6A00A420B0</string>
-				<string>669428F51A009B6A00A420B0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>pop-embedded</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>669428F41A009B6A00A420B0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>669428F51A009B6A00A420B0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>pop-embedded.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>669428F61A009B6A00A420B0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>669428F41A009B6A00A420B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>669428F71A009B6A00A420B0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>669428F51A009B6A00A420B0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68569BF4084F464294AFEBA1</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBReachability.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>7628E8427F4090DD496F92B1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests-osx.gcov.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.gcov.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7BDD7D9C2D2C9AC55E295CD0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests-osx.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7D469990AA7D05FB882F89FC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests-osx.profile.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9062CE2A16BC56CC00655F1D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1318CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>GCOV</string>
-		</dict>
-		<key>9062CE2B16BC56CC00655F1D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1A18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>../Headers/POP</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>GCOV</string>
-		</dict>
-		<key>90AA30B618988BBE00E3BDF7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPSpringSolver.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>90AA30B718988BBE00E3BDF7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90AA30B618988BBE00E3BDF7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9BBD2916A451976950B4C1F6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests-osx.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A2BDDD3D185A687F00838797</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1618CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>A2BDDD3E185A687F00838797</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1A18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>../Headers/POP</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>ADE1BB0636F940EC8EA7EE57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D411892A480A401FB4D1AA07</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B551F115E86E4C7CA0D92E78</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libDoubleConversion.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>BD1A8D5BCA37415F86519334</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libCAres.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>BFD8EB4ECB184EF99C22123A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D075ECD10B62441CBB9A90F6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C4E7267217CE4436805A912B</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBCoreDataKit.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>C5794B0CC3DBDE8D02CF112A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-pop-tests.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D075ECD10B62441CBB9A90F6</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-pop-tests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>D411892A480A401FB4D1AA07</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-pop-tests-osx.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>D52A06EC505A4B82B3BBD5E6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libEvent.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>E5D894724A104C729754ABCA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libGLog.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>EC0AE12F16BC73CE001DA2CE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC0AE13016BC73CE001DA2CE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimationExtras.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC0AE13116BC73CE001DA2CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC0AE12F16BC73CE001DA2CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC0AE13216BC73CE001DA2CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC0AE13016BC73CE001DA2CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC19120D162FB53A00E0CC76</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC19121D162FB53A00E0CC76</string>
-				<string>669428F31A009B6A00A420B0</string>
-				<string>EC882A7518C91983007829CC</string>
-				<string>ECC1DB0718CA291B008C7DEA</string>
-				<string>EC19121A162FB53A00E0CC76</string>
-				<string>EC191219162FB53A00E0CC76</string>
-				<string>4372557D5165714123EC6D70</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19120F162FB53A00E0CC76</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastTestingUpgradeCheck</key>
-				<string>0510</string>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Facebook</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>0B6BE74719FFD3B900762101</key>
-					<dict>
-						<key>CreatedOnToolsVersion</key>
-						<string>6.1</string>
-					</dict>
-					<key>EC7E319818C93D6500B38170</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>EC68857E18C7B60000C6194C</string>
-					</dict>
-					<key>ECF01ED218C92B7F009E0AD1</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>EC191217162FB53A00E0CC76</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>EC191212162FB53A00E0CC76</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>EC19120D162FB53A00E0CC76</string>
-			<key>productRefGroup</key>
-			<string>EC191219162FB53A00E0CC76</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>EC191217162FB53A00E0CC76</string>
-				<string>EC68857E18C7B60000C6194C</string>
-				<string>0B6BE74719FFD3B900762101</string>
-				<string>ECF01ED218C92B7F009E0AD1</string>
-				<string>EC7E319818C93D6500B38170</string>
-			</array>
-		</dict>
-		<key>EC191212162FB53A00E0CC76</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>EC19123B162FB53A00E0CC76</string>
-				<string>9062CE2A16BC56CC00655F1D</string>
-				<string>EC19123C162FB53A00E0CC76</string>
-				<string>A2BDDD3D185A687F00838797</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>EC191214162FB53A00E0CC76</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC191291162FB5B700E0CC76</string>
-				<string>EC6465D11794B4660014176F</string>
-				<string>EC8F014B18FFBC8200DF8905</string>
-				<string>EC8F016A18FFBEB500DF8905</string>
-				<string>EC191292162FB5B700E0CC76</string>
-				<string>EC94B07917D95447003CE2C8</string>
-				<string>EC70AC4418CCF4FC0067018C</string>
-				<string>EC191293162FB5B700E0CC76</string>
-				<string>EC0AE13216BC73CE001DA2CE</string>
-				<string>EC9553911743E278001E6AF2</string>
-				<string>EC94B07E17D95CAA003CE2C8</string>
-				<string>EC35DB2B18EE3E820023E077</string>
-				<string>5E17BB2117457345009842B6</string>
-				<string>EC67007418D3D89F00F7387F</string>
-				<string>ECD80F1318CFD2EF00AE4303</string>
-				<string>EC8F015E18FFBE8C00DF8905</string>
-				<string>EC9997561756A0C300A73F49</string>
-				<string>EC8F015118FFBD3E00DF8905</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC191215162FB53A00E0CC76</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC19121C162FB53A00E0CC76</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC191216162FB53A00E0CC76</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>dstPath</key>
-			<string>include/${PRODUCT_NAME}</string>
-			<key>dstSubfolderSpec</key>
-			<string>16</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXCopyFilesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC191217162FB53A00E0CC76</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>EC19123D162FB53A00E0CC76</string>
-			<key>buildPhases</key>
-			<array>
-				<string>EC191214162FB53A00E0CC76</string>
-				<string>EC191215162FB53A00E0CC76</string>
-				<string>EC191216162FB53A00E0CC76</string>
-				<string>EC191294162FB5DD00E0CC76</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>pop</string>
-			<key>productName</key>
-			<string>POP</string>
-			<key>productReference</key>
-			<string>EC191218162FB53A00E0CC76</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>EC191218162FB53A00E0CC76</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libpop.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>EC191219162FB53A00E0CC76</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC191218162FB53A00E0CC76</string>
-				<string>EC68857F18C7B60000C6194C</string>
-				<string>ECF01ED318C92B7F009E0AD1</string>
-				<string>EC7E319918C93D6500B38170</string>
-				<string>0B6BE74819FFD3B900762101</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19121A162FB53A00E0CC76</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>0B6BE7E619FFD98100762101</string>
-				<string>ECEED93D18C91ACF00DD95F2</string>
-				<string>ECEED93A18C91AB600DD95F2</string>
-				<string>EC6885D318C7C44E00C6194C</string>
-				<string>403DCBBC1783F4A000793AE1</string>
-				<string>ECED421816F7D1FD00FFBEAC</string>
-				<string>68569BF4084F464294AFEBA1</string>
-				<string>ECADA2A416A8A99E00A20182</string>
-				<string>ECADA2A516A8A99E00A20182</string>
-				<string>ECC5A8BA162FBF3A00F7F15C</string>
-				<string>ECC5A8B7162FBE1B00F7F15C</string>
-				<string>ECC5A8B5162FBE1600F7F15C</string>
-				<string>ECC5A8B3162FBE0900F7F15C</string>
-				<string>ECC5A8B1162FBE0400F7F15C</string>
-				<string>ECC5A8AF162FBDF600F7F15C</string>
-				<string>ECC5A8AD162FBDEB00F7F15C</string>
-				<string>ECC5A8AB162FBDE100F7F15C</string>
-				<string>ECC5A8A9162FBDD800F7F15C</string>
-				<string>ECC5A8A7162FBDCF00F7F15C</string>
-				<string>ECC5A8A5162FBDCA00F7F15C</string>
-				<string>ECC5A8A3162FBDC400F7F15C</string>
-				<string>ECC5A8A1162FBDAB00F7F15C</string>
-				<string>ECC5A89F162FBDA400F7F15C</string>
-				<string>ECC5A89D162FBD9B00F7F15C</string>
-				<string>ECC5A89B162FBD9500F7F15C</string>
-				<string>ECC5A899162FBD8E00F7F15C</string>
-				<string>ECC5A897162FBD8700F7F15C</string>
-				<string>ECC5A889162FBD7600F7F15C</string>
-				<string>ECC5A88B162FBD7600F7F15C</string>
-				<string>C4E7267217CE4436805A912B</string>
-				<string>ECC5A88C162FBD7600F7F15C</string>
-				<string>ECC5A88D162FBD7600F7F15C</string>
-				<string>ECC5A88F162FBD7600F7F15C</string>
-				<string>ECC5A887162FBD6200F7F15C</string>
-				<string>EC19121B162FB53A00E0CC76</string>
-				<string>EC19122A162FB53A00E0CC76</string>
-				<string>EC19122C162FB53A00E0CC76</string>
-				<string>E5D894724A104C729754ABCA</string>
-				<string>B551F115E86E4C7CA0D92E78</string>
-				<string>D52A06EC505A4B82B3BBD5E6</string>
-				<string>BD1A8D5BCA37415F86519334</string>
-				<string>ECC63411C31441ECAC3F5559</string>
-				<string>02E3EF56E92B403A9BF79E26</string>
-				<string>EC68858018C7B60000C6194C</string>
-				<string>EC68859518C7B60100C6194C</string>
-				<string>EC68858218C7B60000C6194C</string>
-				<string>D075ECD10B62441CBB9A90F6</string>
-				<string>D411892A480A401FB4D1AA07</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19121B162FB53A00E0CC76</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>EC19121C162FB53A00E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19121B162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC19121D162FB53A00E0CC76</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC8F015918FFBD7A00DF8905</string>
-				<string>EC8F017318FFC4CB00DF8905</string>
-				<string>EC8F017218FFC44800DF8905</string>
-				<string>ECA0D5BE18D818C3003720DF</string>
-				<string>EC6885AF18C7BCA400C6194C</string>
-				<string>EC68858618C7B60000C6194C</string>
-				<string>ECA94D0B18ECAE82002E4CEB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>pop</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19121F162FB53A00E0CC76</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>pop-Prefix.pch</string>
-			<key>path</key>
-			<string>../pop/pop-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19122A162FB53A00E0CC76</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>SenTestingKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/SenTestingKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>EC19122C162FB53A00E0CC76</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>EC191239162FB53A00E0CC76</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19123B162FB53A00E0CC76</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1218CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>EC19123C162FB53A00E0CC76</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1718CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>EC19123D162FB53A00E0CC76</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>EC19123E162FB53A00E0CC76</string>
-				<string>9062CE2B16BC56CC00655F1D</string>
-				<string>EC19123F162FB53A00E0CC76</string>
-				<string>A2BDDD3E185A687F00838797</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>EC19123E162FB53A00E0CC76</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1A18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>../Headers/POP</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>EC19123F162FB53A00E0CC76</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1A18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop/pop-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>../Headers/POP</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>EC191288162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC191289162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19128A162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19128B162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimator.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19128C162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimator.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19128D162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimatorPrivate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19128E162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimatableProperty.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC19128F162FB5B700E0CC76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimatableProperty.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC191291162FB5B700E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191289162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC191292162FB5B700E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128C162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC191293162FB5B700E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128F162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC191294162FB5DD00E0CC76</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>ECD80F1118CFD2EF00AE4303</string>
-				<string>EC1CD95018D80A5C00DE2649</string>
-				<string>EC191295162FB5EC00E0CC76</string>
-				<string>EC191297162FB5EC00E0CC76</string>
-				<string>EC35DB2D18EE3E820023E077</string>
-				<string>EC191299162FB5EC00E0CC76</string>
-				<string>EC8F014F18FFBD3E00DF8905</string>
-				<string>EC8F014018FFBBD300DF8905</string>
-				<string>EC191296162FB5EC00E0CC76</string>
-				<string>EC191298162FB5EC00E0CC76</string>
-				<string>ECCBC57217D96DBD00C69976</string>
-				<string>EC94B07D17D95CAA003CE2C8</string>
-				<string>EC8F016818FFBEB500DF8905</string>
-				<string>5E17BB2017457345009842B6</string>
-				<string>EC67007218D3D89F00F7387F</string>
-				<string>EC8F016218FFBE9D00DF8905</string>
-				<string>EC0AE13116BC73CE001DA2CE</string>
-				<string>EC91E96E18C014DE0025B8AD</string>
-				<string>90AA30B718988BBE00E3BDF7</string>
-				<string>EC8F014618FFBC2D00DF8905</string>
-				<string>EC8F015C18FFBE8C00DF8905</string>
-				<string>EC91E96018C00EC90025B8AD</string>
-				<string>EC70AC4618CCF4FC0067018C</string>
-				<string>EC9553901743E278001E6AF2</string>
-				<string>EC6465D01794B4660014176F</string>
-				<string>EC8F016E18FFBEC200DF8905</string>
-				<string>EC9997551756A0C300A73F49</string>
-				<string>ECA94D0D18ECAE82002E4CEB</string>
-				<string>EC9997591756A17B00A73F49</string>
-				<string>EC94B07A17D95447003CE2C8</string>
-				<string>EC8F015518FFBD5600DF8905</string>
-				<string>EC35DB2918EE3E820023E077</string>
-				<string>ECA0D5C018D8196A003720DF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC191295162FB5EC00E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191288162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC191296162FB5EC00E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128A162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC191297162FB5EC00E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128B162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC191298162FB5EC00E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128D162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC191299162FB5EC00E0CC76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128E162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC1CD94E18D80A5C00DE2649</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationPrivate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC1CD95018D80A5C00DE2649</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC1CD94E18D80A5C00DE2649</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC1CD95118D80A5C00DE2649</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC1CD94E18D80A5C00DE2649</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC35DB2618EE3E820023E077</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationTracer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC35DB2718EE3E820023E077</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimationTracer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC35DB2818EE3E820023E077</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationTracerInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC35DB2918EE3E820023E077</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2618EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC35DB2A18EE3E820023E077</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2618EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC35DB2B18EE3E820023E077</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2718EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC35DB2C18EE3E820023E077</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2718EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC35DB2D18EE3E820023E077</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2818EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC35DB2E18EE3E820023E077</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC35DB2818EE3E820023E077</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC3F125916FB728B00922E3A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimationMRRTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC3F125B16FB78E800922E3A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationTestsExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC3F125C16FB78E800922E3A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimationTestsExtras.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC6465CE1794B4660014176F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPMath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC6465CF1794B4660014176F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPMath.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC6465D01794B4660014176F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6465CE1794B4660014176F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6465D11794B4660014176F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6465CF1794B4660014176F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC67007018D3D89F00F7387F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPCGUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC67007118D3D89F00F7387F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPCGUtils.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC67007218D3D89F00F7387F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC67007018D3D89F00F7387F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC67007318D3D89F00F7387F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC67007018D3D89F00F7387F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC67007418D3D89F00F7387F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC67007118D3D89F00F7387F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC67007518D3D89F00F7387F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC67007118D3D89F00F7387F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC67007618D3D96500F7387F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC67007118D3D89F00F7387F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC67007718D3D96600F7387F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC67007118D3D89F00F7387F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC68857A18C7B60000C6194C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC6885C318C7BD4E00C6194C</string>
-				<string>EC6885B618C7BD2200C6194C</string>
-				<string>EC8F014C18FFBC8200DF8905</string>
-				<string>EC8F016B18FFBEB500DF8905</string>
-				<string>EC6885BE18C7BD4000C6194C</string>
-				<string>EC6885B418C7BD1A00C6194C</string>
-				<string>EC70AC4518CCF4FC0067018C</string>
-				<string>EC6885BC18C7BD3A00C6194C</string>
-				<string>EC6885D218C7BD8900C6194C</string>
-				<string>EC6885B118C7BD1000C6194C</string>
-				<string>EC6885C618C7BD5900C6194C</string>
-				<string>EC35DB2C18EE3E820023E077</string>
-				<string>EC67007518D3D89F00F7387F</string>
-				<string>ECD80F1418CFD2EF00AE4303</string>
-				<string>EC6885C918C7BD6300C6194C</string>
-				<string>EC8F015F18FFBE8C00DF8905</string>
-				<string>EC6885B918C7BD3000C6194C</string>
-				<string>EC8F015218FFBD3E00DF8905</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC68857B18C7B60000C6194C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC6885D418C7C44E00C6194C</string>
-				<string>EC68858118C7B60000C6194C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC68857C18C7B60000C6194C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>ECD80F1218CFD2EF00AE4303</string>
-				<string>EC1CD95118D80A5C00DE2649</string>
-				<string>EC6885D118C7BD8500C6194C</string>
-				<string>EC6885B718C7BD2600C6194C</string>
-				<string>EC35DB2E18EE3E820023E077</string>
-				<string>EC6885C818C7BD5F00C6194C</string>
-				<string>EC8F015018FFBD3E00DF8905</string>
-				<string>EC8F014118FFBBD300DF8905</string>
-				<string>EC6885BB18C7BD3700C6194C</string>
-				<string>EC6885C418C7BD5100C6194C</string>
-				<string>EC6885C518C7BD5500C6194C</string>
-				<string>EC6885CA18C7BD6500C6194C</string>
-				<string>EC8F016918FFBEB500DF8905</string>
-				<string>EC67007318D3D89F00F7387F</string>
-				<string>EC6885B318C7BD1500C6194C</string>
-				<string>EC8F016318FFBE9D00DF8905</string>
-				<string>EC6885CF18C7BD7B00C6194C</string>
-				<string>EC6885D018C7BD7F00C6194C</string>
-				<string>EC70AC4718CCF4FC0067018C</string>
-				<string>EC8F014718FFBC2D00DF8905</string>
-				<string>EC8F015D18FFBE8C00DF8905</string>
-				<string>EC6885BA18C7BD3400C6194C</string>
-				<string>EC6885B518C7BD1C00C6194C</string>
-				<string>EC6885B818C7BD2B00C6194C</string>
-				<string>ECA94D0E18ECAE82002E4CEB</string>
-				<string>EC8F016F18FFBEC200DF8905</string>
-				<string>EC6885C718C7BD5C00C6194C</string>
-				<string>EC6885C218C7BD4B00C6194C</string>
-				<string>EC6885B018C7BD0A00C6194C</string>
-				<string>ECA0D5C118D8196A003720DF</string>
-				<string>EC8F015618FFBD5600DF8905</string>
-				<string>EC35DB2A18EE3E820023E077</string>
-				<string>EC6885BD18C7BD3E00C6194C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC68857D18C7B60000C6194C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC68858B18C7B60000C6194C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC68857E18C7B60000C6194C</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>EC6885A318C7B60100C6194C</string>
-			<key>buildPhases</key>
-			<array>
-				<string>EC68857A18C7B60000C6194C</string>
-				<string>EC68857B18C7B60000C6194C</string>
-				<string>EC68857C18C7B60000C6194C</string>
-				<string>EC68857D18C7B60000C6194C</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>pop-osx</string>
-			<key>productName</key>
-			<string>POP</string>
-			<key>productReference</key>
-			<string>EC68857F18C7B60000C6194C</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>EC68857F18C7B60000C6194C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>pop.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>EC68858018C7B60000C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Cocoa.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/Cocoa.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>EC68858118C7B60000C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC68858018C7B60000C6194C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC68858218C7B60000C6194C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC68858318C7B60000C6194C</string>
-				<string>EC68858418C7B60000C6194C</string>
-				<string>EC68858518C7B60000C6194C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Other Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC68858318C7B60000C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>EC68858418C7B60000C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreData.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/CoreData.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>EC68858518C7B60000C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AppKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/AppKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>EC68858618C7B60000C6194C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC68858818C7B60000C6194C</string>
-				<string>EC68858918C7B60000C6194C</string>
-				<string>EC68858C18C7B60000C6194C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>OSX Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC68858818C7B60000C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>pop-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC68858918C7B60000C6194C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC68858A18C7B60000C6194C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC68858A18C7B60000C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC68858B18C7B60000C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC68858918C7B60000C6194C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC68858C18C7B60000C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>pop-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC68859518C7B60100C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>EC6885A318C7B60100C6194C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>EC6885A418C7B60100C6194C</string>
-				<string>EC6885A518C7B60100C6194C</string>
-				<string>EC6885A618C7B60100C6194C</string>
-				<string>EC6885A718C7B60100C6194C</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>EC6885A418C7B60100C6194C</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1B18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>EC6885A518C7B60100C6194C</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1B18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>GCOV</string>
-		</dict>
-		<key>EC6885A618C7B60100C6194C</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1B18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>EC6885A718C7B60100C6194C</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>ECC1DB1B18CA291B008C7DEA</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop/pop-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>EC6885AF18C7BCA400C6194C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC19121F162FB53A00E0CC76</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS Supporting Files</string>
-			<key>path</key>
-			<string>pop-tests</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>EC6885B018C7BD0A00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128E162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885B118C7BD1000C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128F162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885B318C7BD1500C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191288162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885B418C7BD1A00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191289162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885B518C7BD1C00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997531756A0C300A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885B618C7BD2200C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997541756A0C300A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885B718C7BD2600C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997571756A17B00A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885B818C7BD2B00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC0AE12F16BC73CE001DA2CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885B918C7BD3000C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC0AE13016BC73CE001DA2CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885BA18C7BD3400C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128A162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885BB18C7BD3700C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6465CE1794B4660014176F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885BC18C7BD3A00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6465CF1794B4660014176F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885BD18C7BD3E00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC95538E1743E278001E6AF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885BE18C7BD4000C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC95538F1743E278001E6AF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885C218C7BD4B00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128B162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885C318C7BD4E00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128C162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885C418C7BD5100C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19128D162FB5B700E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885C518C7BD5500C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E17BB1E17457345009842B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885C618C7BD5900C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E17BB1F17457345009842B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885C718C7BD5C00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90AA30B618988BBE00E3BDF7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885C818C7BD5F00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07B17D95CAA003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885C918C7BD6300C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07C17D95CAA003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885CA18C7BD6500C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECCBC57117D96DBD00C69976</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885CF18C7BD7B00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC91E95F18C00EC90025B8AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC6885D018C7BD7F00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC91E96D18C014DE0025B8AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885D118C7BD8500C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07817D95447003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885D218C7BD8900C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07717D95447003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6885D318C7C44E00C6194C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>QuartzCore.framework</string>
-			<key>path</key>
-			<string>Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/QuartzCore.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>EC6885D418C7C44E00C6194C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6885D318C7C44E00C6194C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6C098819141BBD00F8EA96</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPBasicAnimationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC6C098919141BBD00F8EA96</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6C098819141BBD00F8EA96</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6C098A19141BBD00F8EA96</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6C098819141BBD00F8EA96</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC6F55A1175E654B008D995D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPDecayAnimationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC6F55A3175E6641008D995D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPBaseAnimationTests.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC6F55A4175E6641008D995D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPBaseAnimationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC6F55AA175E6B11008D995D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPSpringAnimationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC70AC4218CCF4FC0067018C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPVector.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC70AC4318CCF4FC0067018C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPVector.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC70AC4418CCF4FC0067018C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC70AC4218CCF4FC0067018C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC70AC4518CCF4FC0067018C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC70AC4218CCF4FC0067018C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC70AC4618CCF4FC0067018C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC70AC4318CCF4FC0067018C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC70AC4718CCF4FC0067018C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC70AC4318CCF4FC0067018C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC72875418E13348006EEE54</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPCustomAnimationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC72875518E13348006EEE54</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC72875418E13348006EEE54</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC72875618E13348006EEE54</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC72875418E13348006EEE54</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7D2CFB1795AB3100E50A78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPEaseInEaseOutAnimationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC7E319518C93D6500B38170</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC72875618E13348006EEE54</string>
-				<string>EC7E31AB18C9419000B38170</string>
-				<string>EC7E31AD18C9419600B38170</string>
-				<string>EC6C098A19141BBD00F8EA96</string>
-				<string>EC7E31B318C941A700B38170</string>
-				<string>EC7E31AE18C9419900B38170</string>
-				<string>EC7E31AC18C9419200B38170</string>
-				<string>EC67007718D3D96600F7387F</string>
-				<string>EC7E31B118C941A200B38170</string>
-				<string>EC7E31B018C9419F00B38170</string>
-				<string>EC7E31AF18C9419C00B38170</string>
-				<string>EC7E31B218C941A400B38170</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC7E319618C93D6500B38170</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC7E31B518C9422F00B38170</string>
-				<string>EC7E31B418C9422600B38170</string>
-				<string>EC7E319A18C93D6500B38170</string>
-				<string>ADE1BB0636F940EC8EA7EE57</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC7E319718C93D6500B38170</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC7E31A018C93D6500B38170</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EC7E319818C93D6500B38170</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>EC7E31A618C93D6600B38170</string>
-			<key>buildPhases</key>
-			<array>
-				<string>2F7E04AE9A5B41869AF78DA9</string>
-				<string>EC7E319518C93D6500B38170</string>
-				<string>EC7E319618C93D6500B38170</string>
-				<string>EC7E319718C93D6500B38170</string>
-				<string>063BFBF07EAD4D74B19E2BC0</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>EC7E31A518C93D6600B38170</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>pop-tests-osx</string>
-			<key>productName</key>
-			<string>pop-tests-osx</string>
-			<key>productReference</key>
-			<string>EC7E319918C93D6500B38170</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.ocunit-test</string>
-		</dict>
-		<key>EC7E319918C93D6500B38170</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>pop-tests-osx.octest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>EC7E319A18C93D6500B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19122A162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E319C18C93D6500B38170</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC7E319D18C93D6500B38170</string>
-				<string>EC7E319E18C93D6500B38170</string>
-				<string>EC7E31A318C93D6500B38170</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files - OSX</string>
-			<key>path</key>
-			<string>pop-tests-osx</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>EC7E319D18C93D6500B38170</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>pop-tests-osx-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC7E319E18C93D6500B38170</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC7E319F18C93D6500B38170</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC7E319F18C93D6500B38170</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC7E31A018C93D6500B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC7E319E18C93D6500B38170</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31A318C93D6500B38170</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>pop-tests-OSX-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC7E31A418C93D6600B38170</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>EC19120F162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>EC68857E18C7B60000C6194C</string>
-			<key>remoteInfo</key>
-			<string>POP-OSX</string>
-		</dict>
-		<key>EC7E31A518C93D6600B38170</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>EC68857E18C7B60000C6194C</string>
-			<key>targetProxy</key>
-			<string>EC7E31A418C93D6600B38170</string>
-		</dict>
-		<key>EC7E31A618C93D6600B38170</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>EC7E31A718C93D6600B38170</string>
-				<string>EC7E31A818C93D6600B38170</string>
-				<string>EC7E31A918C93D6600B38170</string>
-				<string>EC7E31AA18C93D6600B38170</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>EC7E31A718C93D6600B38170</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>9BBD2916A451976950B4C1F6</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests-osx/pop-tests-OSX-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop-tests-osx/pop-tests-OSX-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests-osx</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>EC7E31A818C93D6600B38170</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>7628E8427F4090DD496F92B1</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests-osx/pop-tests-OSX-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop-tests-osx/pop-tests-OSX-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests-osx</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>GCOV</string>
-		</dict>
-		<key>EC7E31A918C93D6600B38170</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>7BDD7D9C2D2C9AC55E295CD0</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests-osx/pop-tests-OSX-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop-tests-osx/pop-tests-OSX-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests-osx</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>EC7E31AA18C93D6600B38170</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>7D469990AA7D05FB882F89FC</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests-osx/pop-tests-OSX-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>pop-tests-osx/pop-tests-OSX-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.9</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests-osx</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>EC7E31AB18C9419000B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC99974A17568DAD00A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31AC18C9419200B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6F55A4175E6641008D995D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31AD18C9419600B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191239162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31AE18C9419900B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC3F125916FB728B00922E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>EC7E31AF18C9419C00B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC3F125C16FB78E800922E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31B018C9419F00B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC91D51B16FCC45C00E22B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31B118C941A200B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6F55A1175E654B008D995D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31B218C941A400B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6F55AA175E6B11008D995D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31B318C941A700B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC7D2CFB1795AB3100E50A78</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31B418C9422600B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6885D318C7C44E00C6194C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC7E31B518C9422F00B38170</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC68857F18C7B60000C6194C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC882A7518C91983007829CC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC99974917568DAD00A73F49</string>
-				<string>EC99974A17568DAD00A73F49</string>
-				<string>EC6F55A3175E6641008D995D</string>
-				<string>EC6F55A4175E6641008D995D</string>
-				<string>EC191239162FB53A00E0CC76</string>
-				<string>EC3F125916FB728B00922E3A</string>
-				<string>EC3F125B16FB78E800922E3A</string>
-				<string>EC3F125C16FB78E800922E3A</string>
-				<string>EC91D51B16FCC45C00E22B47</string>
-				<string>EC6F55A1175E654B008D995D</string>
-				<string>EC6F55AA175E6B11008D995D</string>
-				<string>EC7D2CFB1795AB3100E50A78</string>
-				<string>EC72875418E13348006EEE54</string>
-				<string>EC6C098819141BBD00F8EA96</string>
-				<string>EC7E319C18C93D6500B38170</string>
-				<string>EC882A7618C91983007829CC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>pop-tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC882A7618C91983007829CC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC882A7718C91983007829CC</string>
-				<string>EC882A7818C91983007829CC</string>
-				<string>EC882A7D18C91983007829CC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files - iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC882A7718C91983007829CC</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>pop-tests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC882A7818C91983007829CC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC882A7918C91983007829CC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC882A7918C91983007829CC</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC882A7D18C91983007829CC</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>pop-tests-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F013E18FFBBD300DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPPropertyAnimation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F014018FFBBD300DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F013E18FFBBD300DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F014118FFBBD300DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F013E18FFBBD300DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F014418FFBC2D00DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPPropertyAnimationInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F014618FFBC2D00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014418FFBC2D00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F014718FFBC2D00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014418FFBC2D00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F014A18FFBC8200DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPPropertyAnimation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F014B18FFBC8200DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014A18FFBC8200DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F014C18FFBC8200DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014A18FFBC8200DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F014D18FFBD3E00DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPBasicAnimation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F014E18FFBD3E00DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPBasicAnimation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F014F18FFBD3E00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014D18FFBD3E00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F015018FFBD3E00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014D18FFBD3E00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F015118FFBD3E00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014E18FFBD3E00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F015218FFBD3E00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F014E18FFBD3E00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F015318FFBD5600DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPBasicAnimationInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F015518FFBD5600DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015318FFBD5600DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F015618FFBD5600DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015318FFBD5600DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F015918FFBD7A00DF8905</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC191288162FB5B700E0CC76</string>
-				<string>EC191289162FB5B700E0CC76</string>
-				<string>EC19128A162FB5B700E0CC76</string>
-				<string>EC1CD94E18D80A5C00DE2649</string>
-				<string>EC8F013E18FFBBD300DF8905</string>
-				<string>EC8F014A18FFBC8200DF8905</string>
-				<string>EC8F014418FFBC2D00DF8905</string>
-				<string>EC8F014D18FFBD3E00DF8905</string>
-				<string>EC8F014E18FFBD3E00DF8905</string>
-				<string>EC8F015318FFBD5600DF8905</string>
-				<string>5E17BB1E17457345009842B6</string>
-				<string>5E17BB1F17457345009842B6</string>
-				<string>EC8F015A18FFBE8C00DF8905</string>
-				<string>EC8F015B18FFBE8C00DF8905</string>
-				<string>EC8F016018FFBE9D00DF8905</string>
-				<string>EC8F016618FFBEB500DF8905</string>
-				<string>EC8F016718FFBEB500DF8905</string>
-				<string>EC8F016C18FFBEC200DF8905</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Animations</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F015A18FFBE8C00DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPDecayAnimation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F015B18FFBE8C00DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPDecayAnimation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F015C18FFBE8C00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015A18FFBE8C00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F015D18FFBE8C00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015A18FFBE8C00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F015E18FFBE8C00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015B18FFBE8C00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F015F18FFBE8C00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F015B18FFBE8C00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F016018FFBE9D00DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPDecayAnimationInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F016218FFBE9D00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016018FFBE9D00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F016318FFBE9D00DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016018FFBE9D00DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F016618FFBEB500DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPSpringAnimation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F016718FFBEB500DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPSpringAnimation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F016818FFBEB500DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016618FFBEB500DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F016918FFBEB500DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016618FFBEB500DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC8F016A18FFBEB500DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016718FFBEB500DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F016B18FFBEB500DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016718FFBEB500DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F016C18FFBEC200DF8905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPSpringAnimationInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F016E18FFBEC200DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016C18FFBEC200DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F016F18FFBEC200DF8905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC8F016C18FFBEC200DF8905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC8F017218FFC44800DF8905</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC91E96D18C014DE0025B8AD</string>
-				<string>EC67007018D3D89F00F7387F</string>
-				<string>EC67007118D3D89F00F7387F</string>
-				<string>EC91E95F18C00EC90025B8AD</string>
-				<string>ECD80F0F18CFD2EF00AE4303</string>
-				<string>ECD80F1018CFD2EF00AE4303</string>
-				<string>EC94B07B17D95CAA003CE2C8</string>
-				<string>EC94B07C17D95CAA003CE2C8</string>
-				<string>EC6465CE1794B4660014176F</string>
-				<string>EC6465CF1794B4660014176F</string>
-				<string>90AA30B618988BBE00E3BDF7</string>
-				<string>EC70AC4318CCF4FC0067018C</string>
-				<string>EC70AC4218CCF4FC0067018C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Utility</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC8F017318FFC4CB00DF8905</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>EC19128E162FB5B700E0CC76</string>
-				<string>EC19128F162FB5B700E0CC76</string>
-				<string>EC9997531756A0C300A73F49</string>
-				<string>EC9997541756A0C300A73F49</string>
-				<string>EC9997571756A17B00A73F49</string>
-				<string>EC0AE12F16BC73CE001DA2CE</string>
-				<string>EC0AE13016BC73CE001DA2CE</string>
-				<string>EC95538E1743E278001E6AF2</string>
-				<string>EC95538F1743E278001E6AF2</string>
-				<string>EC35DB2618EE3E820023E077</string>
-				<string>EC35DB2718EE3E820023E077</string>
-				<string>EC35DB2818EE3E820023E077</string>
-				<string>EC19128B162FB5B700E0CC76</string>
-				<string>EC19128C162FB5B700E0CC76</string>
-				<string>EC19128D162FB5B700E0CC76</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Engine</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC91D51B16FCC45C00E22B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimatablePropertyTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC91E95F18C00EC90025B8AD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPDefines.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC91E96018C00EC90025B8AD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC91E95F18C00EC90025B8AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC91E96D18C014DE0025B8AD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAction.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC91E96E18C014DE0025B8AD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC91E96D18C014DE0025B8AD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC94B07717D95447003CE2C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>name</key>
-			<string>TransformationMatrix.cpp</string>
-			<key>path</key>
-			<string>WebCore/TransformationMatrix.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC94B07817D95447003CE2C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>TransformationMatrix.h</string>
-			<key>path</key>
-			<string>WebCore/TransformationMatrix.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC94B07917D95447003CE2C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07717D95447003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC94B07A17D95447003CE2C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07817D95447003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC94B07B17D95CAA003CE2C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPLayerExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC94B07C17D95CAA003CE2C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPLayerExtras.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC94B07D17D95CAA003CE2C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07B17D95CAA003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC94B07E17D95CAA003CE2C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC94B07C17D95CAA003CE2C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC95538E1743E278001E6AF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationRuntime.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC95538F1743E278001E6AF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimationRuntime.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC9553901743E278001E6AF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC95538E1743E278001E6AF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC9553911743E278001E6AF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC95538F1743E278001E6AF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC99974917568DAD00A73F49</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>POPAnimatable.h</string>
-			<key>path</key>
-			<string>pop-tests/POPAnimatable.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>EC99974A17568DAD00A73F49</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>POPAnimatable.mm</string>
-			<key>path</key>
-			<string>pop-tests/POPAnimatable.mm</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>EC9997531756A0C300A73F49</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationEvent.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC9997541756A0C300A73F49</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPAnimationEvent.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC9997551756A0C300A73F49</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997531756A0C300A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>EC9997561756A0C300A73F49</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997541756A0C300A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EC9997571756A17B00A73F49</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPAnimationEventInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>EC9997591756A17B00A73F49</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC9997571756A17B00A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECA0D5BE18D818C3003720DF</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ECCBC57117D96DBD00C69976</string>
-				<string>EC94B07817D95447003CE2C8</string>
-				<string>EC94B07717D95447003CE2C8</string>
-				<string>ECA0D5BF18D8196A003720DF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>WebCore</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECA0D5BF18D8196A003720DF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>UnitBezier.h</string>
-			<key>path</key>
-			<string>WebCore/UnitBezier.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECA0D5C018D8196A003720DF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECA0D5BF18D8196A003720DF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECA0D5C118D8196A003720DF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECA0D5BF18D8196A003720DF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECA94D0B18ECAE82002E4CEB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>POP.h</string>
-			<key>path</key>
-			<string>pop/POP.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>ECA94D0D18ECAE82002E4CEB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECA94D0B18ECAE82002E4CEB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>ECA94D0E18ECAE82002E4CEB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECA94D0B18ECAE82002E4CEB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>ECADA2A416A8A99E00A20182</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libMessagePack.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECADA2A516A8A99E00A20182</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libSPDY.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECC1DB0718CA291B008C7DEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ECC1DB0818CA291B008C7DEA</string>
-				<string>ECC1DB0B18CA291B008C7DEA</string>
-				<string>ECC1DB0C18CA291B008C7DEA</string>
-				<string>0BA2A8F119FFDC7F00B28783</string>
-				<string>ECC1DB0D18CA291B008C7DEA</string>
-				<string>ECC1DB1118CA291B008C7DEA</string>
-				<string>ECC1DB1918CA291B008C7DEA</string>
-				<string>ECC1DB1C18CA291B008C7DEA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Configuration</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0818CA291B008C7DEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ECC1DB0918CA291B008C7DEA</string>
-				<string>ECC1DB0A18CA291B008C7DEA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Applications</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0918CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Application-iOS.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0A18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Application-OSX.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0B18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Base-iOS.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0C18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Base-OSX.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0D18CA291B008C7DEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ECC1DB0E18CA291B008C7DEA</string>
-				<string>ECC1DB0F18CA291B008C7DEA</string>
-				<string>ECC1DB1018CA291B008C7DEA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Platform</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0E18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Compiler.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB0F18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>iOS.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1018CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>OSX.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1118CA291B008C7DEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ECC1DB1218CA291B008C7DEA</string>
-				<string>ECC1DB1318CA291B008C7DEA</string>
-				<string>ECC1DB1618CA291B008C7DEA</string>
-				<string>ECC1DB1718CA291B008C7DEA</string>
-				<string>ECC1DB1818CA291B008C7DEA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Projects</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1218CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Project-Debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1318CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Project-GCOV.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1618CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Project-Profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1718CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Project-Release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1818CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Project.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1918CA291B008C7DEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ECC1DB1A18CA291B008C7DEA</string>
-				<string>ECC1DB1B18CA291B008C7DEA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Static Libraries</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1A18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>StaticLibrary-iOS.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1B18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>StaticLibrary-OSX.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1C18CA291B008C7DEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>ECC1DB1D18CA291B008C7DEA</string>
-				<string>ECC1DB1E18CA291B008C7DEA</string>
-				<string>ECC1DB1F18CA291B008C7DEA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1D18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>ApplicationTests.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1E18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>LogicTests-iOS.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC1DB1F18CA291B008C7DEA</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>LogicTests-OSX.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECC5A887162FBD6200F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>QuartzCore.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/QuartzCore.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A889162FBD7600F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBAnalytics.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECC5A88B162FBD7600F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBFoundation.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECC5A88C162FBD7600F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBProvider.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECC5A88D162FBD7600F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBTest.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECC5A88F162FBD7600F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libOCMock.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECC5A897162FBD8700F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AddressBook.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AddressBook.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A899162FBD8E00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CFNetwork.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CFNetwork.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A89B162FBD9500F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AudioToolbox.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AudioToolbox.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A89D162FBD9B00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A89F162FBDA400F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreData.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreData.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8A1162FBDAB00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>MobileCoreServices.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/MobileCoreServices.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8A3162FBDC400F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Accounts.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Accounts.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8A5162FBDCA00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AVFoundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AVFoundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8A7162FBDCF00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreLocation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreLocation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8A9162FBDD800F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>SystemConfiguration.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/SystemConfiguration.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8AB162FBDE100F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>ImageIO.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/ImageIO.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8AD162FBDEB00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreText.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreText.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8AF162FBDF600F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreTelephony.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreTelephony.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8B1162FBE0400F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>compiled.mach-o.dylib</string>
-			<key>name</key>
-			<string>libz.dylib</string>
-			<key>path</key>
-			<string>usr/lib/libz.dylib</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8B3162FBE0900F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>compiled.mach-o.dylib</string>
-			<key>name</key>
-			<string>libicucore.dylib</string>
-			<key>path</key>
-			<string>usr/lib/libicucore.dylib</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8B5162FBE1600F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AssetsLibrary.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AssetsLibrary.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8B7162FBE1B00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Security.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Security.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC5A8BA162FBF3A00F7F15C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AdSupport.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AdSupport.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECC63411C31441ECAC3F5559</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libLiger.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECCBC57117D96DBD00C69976</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>FloatConversion.h</string>
-			<key>path</key>
-			<string>WebCore/FloatConversion.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECCBC57217D96DBD00C69976</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECCBC57117D96DBD00C69976</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECD80F0F18CFD2EF00AE4303</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>POPGeometry.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECD80F1018CFD2EF00AE4303</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>POPGeometry.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ECD80F1118CFD2EF00AE4303</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECD80F0F18CFD2EF00AE4303</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>ECD80F1218CFD2EF00AE4303</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECD80F0F18CFD2EF00AE4303</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>ECD80F1318CFD2EF00AE4303</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECD80F1018CFD2EF00AE4303</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECD80F1418CFD2EF00AE4303</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECD80F1018CFD2EF00AE4303</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CC618C92BC900D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC99974A17568DAD00A73F49</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CC718C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6F55A4175E6641008D995D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CC818C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191239162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CC918C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC3F125916FB728B00922E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>ECDA0CCA18C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC3F125C16FB78E800922E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CCB18C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC91D51B16FCC45C00E22B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CCC18C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6F55A1175E654B008D995D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CCD18C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC6F55AA175E6B11008D995D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CCE18C92BD200D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC7D2CFB1795AB3100E50A78</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CCF18C92C3E00D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECC5A887162FBD6200F7F15C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CD018C92C4C00D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC191218162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECDA0CD118C92D3900D14897</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECC5A89D162FBD9B00F7F15C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECED421816F7D1FD00FFBEAC</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libFBNetworker.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECEED93A18C91AB600DD95F2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>path</key>
-			<string>libOCMock.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECEED93D18C91ACF00DD95F2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>ECF01ECF18C92B7F009E0AD1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>EC72875518E13348006EEE54</string>
-				<string>ECDA0CC618C92BC900D14897</string>
-				<string>ECDA0CC818C92BD200D14897</string>
-				<string>EC6C098919141BBD00F8EA96</string>
-				<string>ECDA0CCE18C92BD200D14897</string>
-				<string>ECDA0CC918C92BD200D14897</string>
-				<string>ECDA0CC718C92BD200D14897</string>
-				<string>EC67007618D3D96500F7387F</string>
-				<string>ECDA0CCC18C92BD200D14897</string>
-				<string>ECDA0CCB18C92BD200D14897</string>
-				<string>ECDA0CCA18C92BD200D14897</string>
-				<string>ECDA0CCD18C92BD200D14897</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>ECF01ED018C92B7F009E0AD1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>ECDA0CD118C92D3900D14897</string>
-				<string>ECDA0CD018C92C4C00D14897</string>
-				<string>ECDA0CCF18C92C3E00D14897</string>
-				<string>ECF01ED418C92B7F009E0AD1</string>
-				<string>ECF01ED618C92B7F009E0AD1</string>
-				<string>ECF01ED518C92B7F009E0AD1</string>
-				<string>BFD8EB4ECB184EF99C22123A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>ECF01ED118C92B7F009E0AD1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>ECF01ED218C92B7F009E0AD1</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>ECF01EE218C92B80009E0AD1</string>
-			<key>buildPhases</key>
-			<array>
-				<string>093AEF8FEE094AECB5EDCED2</string>
-				<string>ECF01ECF18C92B7F009E0AD1</string>
-				<string>ECF01ED018C92B7F009E0AD1</string>
-				<string>ECF01ED118C92B7F009E0AD1</string>
-				<string>394D14BF947A476EB827103B</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>ECF01EE118C92B80009E0AD1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>pop-tests</string>
-			<key>productName</key>
-			<string>pop-tests</string>
-			<key>productReference</key>
-			<string>ECF01ED318C92B7F009E0AD1</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.ocunit-test</string>
-		</dict>
-		<key>ECF01ED318C92B7F009E0AD1</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>pop-tests.octest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>ECF01ED418C92B7F009E0AD1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19122A162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECF01ED518C92B7F009E0AD1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EC19121B162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECF01ED618C92B7F009E0AD1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ECEED93D18C91ACF00DD95F2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ECF01EE018C92B80009E0AD1</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>EC19120F162FB53A00E0CC76</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>EC191217162FB53A00E0CC76</string>
-			<key>remoteInfo</key>
-			<string>POP</string>
-		</dict>
-		<key>ECF01EE118C92B80009E0AD1</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>EC191217162FB53A00E0CC76</string>
-			<key>targetProxy</key>
-			<string>ECF01EE018C92B80009E0AD1</string>
-		</dict>
-		<key>ECF01EE218C92B80009E0AD1</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>ECF01EE318C92B80009E0AD1</string>
-				<string>ECF01EE418C92B80009E0AD1</string>
-				<string>ECF01EE518C92B80009E0AD1</string>
-				<string>ECF01EE618C92B80009E0AD1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>ECF01EE318C92B80009E0AD1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>4F4245BFB89B6239FE145E69</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests/pop-tests-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>ECF01EE418C92B80009E0AD1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>408E6FF86BDD3F47FC44BF6A</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests/pop-tests-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>GCOV</string>
-		</dict>
-		<key>ECF01EE518C92B80009E0AD1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>C5794B0CC3DBDE8D02CF112A</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests/pop-tests-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>ECF01EE618C92B80009E0AD1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3606F0C22CF0EB387E8AC270</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>pop-tests/pop-tests-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_SHADOW</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>PRODUCT_NAME</key>
-				<string>pop-tests</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>octest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>EC19120F162FB53A00E0CC76</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0B6BE76819FFD3FF00762101 /* POPAnimationTracer.h in Headers */ = {isa = PBXBuildFile; fileRef = EC35DB2618EE3E820023E077 /* POPAnimationTracer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE76919FFD40700762101 /* POP.h in Headers */ = {isa = PBXBuildFile; fileRef = ECA94D0B18ECAE82002E4CEB /* POP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE76A19FFD41100762101 /* POPAnimationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = EC9997531756A0C300A73F49 /* POPAnimationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE76B19FFD41500762101 /* POPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EC91E95F18C00EC90025B8AD /* POPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE76C19FFD41D00762101 /* POPDecayAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F015A18FFBE8C00DF8905 /* POPDecayAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE76D19FFD42700762101 /* POPAnimationExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = EC0AE12F16BC73CE001DA2CE /* POPAnimationExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE76E19FFD43800762101 /* POPCustomAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E17BB1E17457345009842B6 /* POPCustomAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE76F19FFD44000762101 /* POPSpringAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F016618FFBEB500DF8905 /* POPSpringAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77019FFD46600762101 /* POPLayerExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = EC94B07B17D95CAA003CE2C8 /* POPLayerExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77119FFD46F00762101 /* POPAnimatorPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128D162FB5B700E0CC76 /* POPAnimatorPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77219FFD47800762101 /* POPPropertyAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F013E18FFBBD300DF8905 /* POPPropertyAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77319FFD47F00762101 /* POPBasicAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F014D18FFBD3E00DF8905 /* POPBasicAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77419FFD48700762101 /* POPAnimatableProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128E162FB5B700E0CC76 /* POPAnimatableProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77519FFD49100762101 /* POPAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128B162FB5B700E0CC76 /* POPAnimator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77619FFD49A00762101 /* POPAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC191288162FB5B700E0CC76 /* POPAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77719FFD4A300762101 /* POPAnimationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EC1CD94E18D80A5C00DE2649 /* POPAnimationPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE77819FFD4AB00762101 /* POPGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = ECD80F0F18CFD2EF00AE4303 /* POPGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B6BE7D019FFD90F00762101 /* TransformationMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC94B07717D95447003CE2C8 /* TransformationMatrix.cpp */; };
+		0B6BE7D119FFD92700762101 /* POPAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC191289162FB5B700E0CC76 /* POPAnimation.mm */; };
+		0B6BE7D219FFD92700762101 /* POPPropertyAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F014A18FFBC8200DF8905 /* POPPropertyAnimation.mm */; };
+		0B6BE7D319FFD92700762101 /* POPBasicAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F014E18FFBD3E00DF8905 /* POPBasicAnimation.mm */; };
+		0B6BE7D419FFD92700762101 /* POPCustomAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E17BB1F17457345009842B6 /* POPCustomAnimation.mm */; };
+		0B6BE7D519FFD92700762101 /* POPDecayAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F015B18FFBE8C00DF8905 /* POPDecayAnimation.mm */; };
+		0B6BE7D619FFD92700762101 /* POPSpringAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F016718FFBEB500DF8905 /* POPSpringAnimation.mm */; };
+		0B6BE7D719FFD92700762101 /* POPAnimatableProperty.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC19128F162FB5B700E0CC76 /* POPAnimatableProperty.mm */; };
+		0B6BE7D819FFD92700762101 /* POPAnimationEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC9997541756A0C300A73F49 /* POPAnimationEvent.mm */; };
+		0B6BE7D919FFD92700762101 /* POPAnimationExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC0AE13016BC73CE001DA2CE /* POPAnimationExtras.mm */; };
+		0B6BE7DA19FFD92700762101 /* POPAnimationRuntime.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC95538F1743E278001E6AF2 /* POPAnimationRuntime.mm */; };
+		0B6BE7DB19FFD92700762101 /* POPAnimationTracer.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC35DB2718EE3E820023E077 /* POPAnimationTracer.mm */; };
+		0B6BE7DC19FFD92700762101 /* POPAnimator.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC19128C162FB5B700E0CC76 /* POPAnimator.mm */; };
+		0B6BE7DD19FFD92700762101 /* POPCGUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC67007118D3D89F00F7387F /* POPCGUtils.mm */; };
+		0B6BE7DE19FFD92700762101 /* POPGeometry.mm in Sources */ = {isa = PBXBuildFile; fileRef = ECD80F1018CFD2EF00AE4303 /* POPGeometry.mm */; };
+		0B6BE7DF19FFD92700762101 /* POPLayerExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC94B07C17D95CAA003CE2C8 /* POPLayerExtras.mm */; };
+		0B6BE7E019FFD92800762101 /* POPMath.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6465CF1794B4660014176F /* POPMath.mm */; };
+		0B6BE7E119FFD92800762101 /* POPVector.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC70AC4218CCF4FC0067018C /* POPVector.mm */; };
+		5E17BB2017457345009842B6 /* POPCustomAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E17BB1E17457345009842B6 /* POPCustomAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E17BB2117457345009842B6 /* POPCustomAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E17BB1F17457345009842B6 /* POPCustomAnimation.mm */; };
+		669428F61A009B6A00A420B0 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 669428F41A009B6A00A420B0 /* Info.plist */; };
+		669428F71A009B6A00A420B0 /* pop-embedded.h in Headers */ = {isa = PBXBuildFile; fileRef = 669428F51A009B6A00A420B0 /* pop-embedded.h */; };
+		90AA30B718988BBE00E3BDF7 /* POPSpringSolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 90AA30B618988BBE00E3BDF7 /* POPSpringSolver.h */; };
+		ADE1BB0636F940EC8EA7EE57 /* libPods-pop-tests-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D411892A480A401FB4D1AA07 /* libPods-pop-tests-osx.a */; };
+		BFD8EB4ECB184EF99C22123A /* libPods-pop-tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D075ECD10B62441CBB9A90F6 /* libPods-pop-tests.a */; };
+		EC0AE13116BC73CE001DA2CE /* POPAnimationExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = EC0AE12F16BC73CE001DA2CE /* POPAnimationExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC0AE13216BC73CE001DA2CE /* POPAnimationExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC0AE13016BC73CE001DA2CE /* POPAnimationExtras.mm */; };
+		EC19121C162FB53A00E0CC76 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC19121B162FB53A00E0CC76 /* Foundation.framework */; };
+		EC191291162FB5B700E0CC76 /* POPAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC191289162FB5B700E0CC76 /* POPAnimation.mm */; };
+		EC191292162FB5B700E0CC76 /* POPAnimator.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC19128C162FB5B700E0CC76 /* POPAnimator.mm */; };
+		EC191293162FB5B700E0CC76 /* POPAnimatableProperty.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC19128F162FB5B700E0CC76 /* POPAnimatableProperty.mm */; };
+		EC191295162FB5EC00E0CC76 /* POPAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC191288162FB5B700E0CC76 /* POPAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC191296162FB5EC00E0CC76 /* POPAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128A162FB5B700E0CC76 /* POPAnimationInternal.h */; };
+		EC191297162FB5EC00E0CC76 /* POPAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128B162FB5B700E0CC76 /* POPAnimator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC191298162FB5EC00E0CC76 /* POPAnimatorPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128D162FB5B700E0CC76 /* POPAnimatorPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC191299162FB5EC00E0CC76 /* POPAnimatableProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128E162FB5B700E0CC76 /* POPAnimatableProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC1CD95018D80A5C00DE2649 /* POPAnimationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EC1CD94E18D80A5C00DE2649 /* POPAnimationPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC1CD95118D80A5C00DE2649 /* POPAnimationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EC1CD94E18D80A5C00DE2649 /* POPAnimationPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC35DB2918EE3E820023E077 /* POPAnimationTracer.h in Headers */ = {isa = PBXBuildFile; fileRef = EC35DB2618EE3E820023E077 /* POPAnimationTracer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC35DB2A18EE3E820023E077 /* POPAnimationTracer.h in Headers */ = {isa = PBXBuildFile; fileRef = EC35DB2618EE3E820023E077 /* POPAnimationTracer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC35DB2B18EE3E820023E077 /* POPAnimationTracer.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC35DB2718EE3E820023E077 /* POPAnimationTracer.mm */; };
+		EC35DB2C18EE3E820023E077 /* POPAnimationTracer.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC35DB2718EE3E820023E077 /* POPAnimationTracer.mm */; };
+		EC35DB2D18EE3E820023E077 /* POPAnimationTracerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC35DB2818EE3E820023E077 /* POPAnimationTracerInternal.h */; };
+		EC35DB2E18EE3E820023E077 /* POPAnimationTracerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC35DB2818EE3E820023E077 /* POPAnimationTracerInternal.h */; };
+		EC6465D01794B4660014176F /* POPMath.h in Headers */ = {isa = PBXBuildFile; fileRef = EC6465CE1794B4660014176F /* POPMath.h */; };
+		EC6465D11794B4660014176F /* POPMath.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6465CF1794B4660014176F /* POPMath.mm */; };
+		EC67007218D3D89F00F7387F /* POPCGUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = EC67007018D3D89F00F7387F /* POPCGUtils.h */; };
+		EC67007318D3D89F00F7387F /* POPCGUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = EC67007018D3D89F00F7387F /* POPCGUtils.h */; };
+		EC67007418D3D89F00F7387F /* POPCGUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC67007118D3D89F00F7387F /* POPCGUtils.mm */; };
+		EC67007518D3D89F00F7387F /* POPCGUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC67007118D3D89F00F7387F /* POPCGUtils.mm */; };
+		EC67007618D3D96500F7387F /* POPCGUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC67007118D3D89F00F7387F /* POPCGUtils.mm */; };
+		EC67007718D3D96600F7387F /* POPCGUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC67007118D3D89F00F7387F /* POPCGUtils.mm */; };
+		EC68858118C7B60000C6194C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC68858018C7B60000C6194C /* Cocoa.framework */; };
+		EC68858B18C7B60000C6194C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = EC68858918C7B60000C6194C /* InfoPlist.strings */; };
+		EC6885B018C7BD0A00C6194C /* POPAnimatableProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128E162FB5B700E0CC76 /* POPAnimatableProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885B118C7BD1000C6194C /* POPAnimatableProperty.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC19128F162FB5B700E0CC76 /* POPAnimatableProperty.mm */; };
+		EC6885B318C7BD1500C6194C /* POPAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC191288162FB5B700E0CC76 /* POPAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885B418C7BD1A00C6194C /* POPAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC191289162FB5B700E0CC76 /* POPAnimation.mm */; };
+		EC6885B518C7BD1C00C6194C /* POPAnimationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = EC9997531756A0C300A73F49 /* POPAnimationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885B618C7BD2200C6194C /* POPAnimationEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC9997541756A0C300A73F49 /* POPAnimationEvent.mm */; };
+		EC6885B718C7BD2600C6194C /* POPAnimationEventInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC9997571756A17B00A73F49 /* POPAnimationEventInternal.h */; };
+		EC6885B818C7BD2B00C6194C /* POPAnimationExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = EC0AE12F16BC73CE001DA2CE /* POPAnimationExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885B918C7BD3000C6194C /* POPAnimationExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC0AE13016BC73CE001DA2CE /* POPAnimationExtras.mm */; };
+		EC6885BA18C7BD3400C6194C /* POPAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128A162FB5B700E0CC76 /* POPAnimationInternal.h */; };
+		EC6885BB18C7BD3700C6194C /* POPMath.h in Headers */ = {isa = PBXBuildFile; fileRef = EC6465CE1794B4660014176F /* POPMath.h */; };
+		EC6885BC18C7BD3A00C6194C /* POPMath.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6465CF1794B4660014176F /* POPMath.mm */; };
+		EC6885BD18C7BD3E00C6194C /* POPAnimationRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = EC95538E1743E278001E6AF2 /* POPAnimationRuntime.h */; };
+		EC6885BE18C7BD4000C6194C /* POPAnimationRuntime.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC95538F1743E278001E6AF2 /* POPAnimationRuntime.mm */; };
+		EC6885C218C7BD4B00C6194C /* POPAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128B162FB5B700E0CC76 /* POPAnimator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885C318C7BD4E00C6194C /* POPAnimator.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC19128C162FB5B700E0CC76 /* POPAnimator.mm */; };
+		EC6885C418C7BD5100C6194C /* POPAnimatorPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EC19128D162FB5B700E0CC76 /* POPAnimatorPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885C518C7BD5500C6194C /* POPCustomAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E17BB1E17457345009842B6 /* POPCustomAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885C618C7BD5900C6194C /* POPCustomAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E17BB1F17457345009842B6 /* POPCustomAnimation.mm */; };
+		EC6885C718C7BD5C00C6194C /* POPSpringSolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 90AA30B618988BBE00E3BDF7 /* POPSpringSolver.h */; };
+		EC6885C818C7BD5F00C6194C /* POPLayerExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = EC94B07B17D95CAA003CE2C8 /* POPLayerExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885C918C7BD6300C6194C /* POPLayerExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC94B07C17D95CAA003CE2C8 /* POPLayerExtras.mm */; };
+		EC6885CA18C7BD6500C6194C /* FloatConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = ECCBC57117D96DBD00C69976 /* FloatConversion.h */; };
+		EC6885CF18C7BD7B00C6194C /* POPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EC91E95F18C00EC90025B8AD /* POPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC6885D018C7BD7F00C6194C /* POPAction.h in Headers */ = {isa = PBXBuildFile; fileRef = EC91E96D18C014DE0025B8AD /* POPAction.h */; };
+		EC6885D118C7BD8500C6194C /* TransformationMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = EC94B07817D95447003CE2C8 /* TransformationMatrix.h */; };
+		EC6885D218C7BD8900C6194C /* TransformationMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC94B07717D95447003CE2C8 /* TransformationMatrix.cpp */; };
+		EC6885D418C7C44E00C6194C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC6885D318C7C44E00C6194C /* QuartzCore.framework */; };
+		EC6C098919141BBD00F8EA96 /* POPBasicAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6C098819141BBD00F8EA96 /* POPBasicAnimationTests.mm */; };
+		EC6C098A19141BBD00F8EA96 /* POPBasicAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6C098819141BBD00F8EA96 /* POPBasicAnimationTests.mm */; };
+		EC70AC4418CCF4FC0067018C /* POPVector.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC70AC4218CCF4FC0067018C /* POPVector.mm */; };
+		EC70AC4518CCF4FC0067018C /* POPVector.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC70AC4218CCF4FC0067018C /* POPVector.mm */; };
+		EC70AC4618CCF4FC0067018C /* POPVector.h in Headers */ = {isa = PBXBuildFile; fileRef = EC70AC4318CCF4FC0067018C /* POPVector.h */; };
+		EC70AC4718CCF4FC0067018C /* POPVector.h in Headers */ = {isa = PBXBuildFile; fileRef = EC70AC4318CCF4FC0067018C /* POPVector.h */; };
+		EC72875518E13348006EEE54 /* POPCustomAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC72875418E13348006EEE54 /* POPCustomAnimationTests.mm */; };
+		EC72875618E13348006EEE54 /* POPCustomAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC72875418E13348006EEE54 /* POPCustomAnimationTests.mm */; };
+		EC7E319A18C93D6500B38170 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC19122A162FB53A00E0CC76 /* SenTestingKit.framework */; };
+		EC7E31A018C93D6500B38170 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = EC7E319E18C93D6500B38170 /* InfoPlist.strings */; };
+		EC7E31AB18C9419000B38170 /* POPAnimatable.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC99974A17568DAD00A73F49 /* POPAnimatable.mm */; };
+		EC7E31AC18C9419200B38170 /* POPBaseAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6F55A4175E6641008D995D /* POPBaseAnimationTests.mm */; };
+		EC7E31AD18C9419600B38170 /* POPAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC191239162FB53A00E0CC76 /* POPAnimationTests.mm */; };
+		EC7E31AE18C9419900B38170 /* POPAnimationMRRTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC3F125916FB728B00922E3A /* POPAnimationMRRTests.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		EC7E31AF18C9419C00B38170 /* POPAnimationTestsExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC3F125C16FB78E800922E3A /* POPAnimationTestsExtras.mm */; };
+		EC7E31B018C9419F00B38170 /* POPAnimatablePropertyTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC91D51B16FCC45C00E22B47 /* POPAnimatablePropertyTests.mm */; };
+		EC7E31B118C941A200B38170 /* POPDecayAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6F55A1175E654B008D995D /* POPDecayAnimationTests.mm */; };
+		EC7E31B218C941A400B38170 /* POPSpringAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6F55AA175E6B11008D995D /* POPSpringAnimationTests.mm */; };
+		EC7E31B318C941A700B38170 /* POPEaseInEaseOutAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC7D2CFB1795AB3100E50A78 /* POPEaseInEaseOutAnimationTests.mm */; };
+		EC7E31B418C9422600B38170 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC6885D318C7C44E00C6194C /* QuartzCore.framework */; };
+		EC7E31B518C9422F00B38170 /* pop.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC68857F18C7B60000C6194C /* pop.framework */; };
+		EC8F014018FFBBD300DF8905 /* POPPropertyAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F013E18FFBBD300DF8905 /* POPPropertyAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F014118FFBBD300DF8905 /* POPPropertyAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F013E18FFBBD300DF8905 /* POPPropertyAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F014618FFBC2D00DF8905 /* POPPropertyAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F014418FFBC2D00DF8905 /* POPPropertyAnimationInternal.h */; };
+		EC8F014718FFBC2D00DF8905 /* POPPropertyAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F014418FFBC2D00DF8905 /* POPPropertyAnimationInternal.h */; };
+		EC8F014B18FFBC8200DF8905 /* POPPropertyAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F014A18FFBC8200DF8905 /* POPPropertyAnimation.mm */; };
+		EC8F014C18FFBC8200DF8905 /* POPPropertyAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F014A18FFBC8200DF8905 /* POPPropertyAnimation.mm */; };
+		EC8F014F18FFBD3E00DF8905 /* POPBasicAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F014D18FFBD3E00DF8905 /* POPBasicAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F015018FFBD3E00DF8905 /* POPBasicAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F014D18FFBD3E00DF8905 /* POPBasicAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F015118FFBD3E00DF8905 /* POPBasicAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F014E18FFBD3E00DF8905 /* POPBasicAnimation.mm */; };
+		EC8F015218FFBD3E00DF8905 /* POPBasicAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F014E18FFBD3E00DF8905 /* POPBasicAnimation.mm */; };
+		EC8F015518FFBD5600DF8905 /* POPBasicAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F015318FFBD5600DF8905 /* POPBasicAnimationInternal.h */; };
+		EC8F015618FFBD5600DF8905 /* POPBasicAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F015318FFBD5600DF8905 /* POPBasicAnimationInternal.h */; };
+		EC8F015C18FFBE8C00DF8905 /* POPDecayAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F015A18FFBE8C00DF8905 /* POPDecayAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F015D18FFBE8C00DF8905 /* POPDecayAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F015A18FFBE8C00DF8905 /* POPDecayAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F015E18FFBE8C00DF8905 /* POPDecayAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F015B18FFBE8C00DF8905 /* POPDecayAnimation.mm */; };
+		EC8F015F18FFBE8C00DF8905 /* POPDecayAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F015B18FFBE8C00DF8905 /* POPDecayAnimation.mm */; };
+		EC8F016218FFBE9D00DF8905 /* POPDecayAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F016018FFBE9D00DF8905 /* POPDecayAnimationInternal.h */; };
+		EC8F016318FFBE9D00DF8905 /* POPDecayAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F016018FFBE9D00DF8905 /* POPDecayAnimationInternal.h */; };
+		EC8F016818FFBEB500DF8905 /* POPSpringAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F016618FFBEB500DF8905 /* POPSpringAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F016918FFBEB500DF8905 /* POPSpringAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F016618FFBEB500DF8905 /* POPSpringAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC8F016A18FFBEB500DF8905 /* POPSpringAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F016718FFBEB500DF8905 /* POPSpringAnimation.mm */; };
+		EC8F016B18FFBEB500DF8905 /* POPSpringAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC8F016718FFBEB500DF8905 /* POPSpringAnimation.mm */; };
+		EC8F016E18FFBEC200DF8905 /* POPSpringAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F016C18FFBEC200DF8905 /* POPSpringAnimationInternal.h */; };
+		EC8F016F18FFBEC200DF8905 /* POPSpringAnimationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8F016C18FFBEC200DF8905 /* POPSpringAnimationInternal.h */; };
+		EC91E96018C00EC90025B8AD /* POPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EC91E95F18C00EC90025B8AD /* POPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC91E96E18C014DE0025B8AD /* POPAction.h in Headers */ = {isa = PBXBuildFile; fileRef = EC91E96D18C014DE0025B8AD /* POPAction.h */; };
+		EC94B07917D95447003CE2C8 /* TransformationMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC94B07717D95447003CE2C8 /* TransformationMatrix.cpp */; };
+		EC94B07A17D95447003CE2C8 /* TransformationMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = EC94B07817D95447003CE2C8 /* TransformationMatrix.h */; };
+		EC94B07D17D95CAA003CE2C8 /* POPLayerExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = EC94B07B17D95CAA003CE2C8 /* POPLayerExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC94B07E17D95CAA003CE2C8 /* POPLayerExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC94B07C17D95CAA003CE2C8 /* POPLayerExtras.mm */; };
+		EC9553901743E278001E6AF2 /* POPAnimationRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = EC95538E1743E278001E6AF2 /* POPAnimationRuntime.h */; };
+		EC9553911743E278001E6AF2 /* POPAnimationRuntime.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC95538F1743E278001E6AF2 /* POPAnimationRuntime.mm */; };
+		EC9997551756A0C300A73F49 /* POPAnimationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = EC9997531756A0C300A73F49 /* POPAnimationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC9997561756A0C300A73F49 /* POPAnimationEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC9997541756A0C300A73F49 /* POPAnimationEvent.mm */; };
+		EC9997591756A17B00A73F49 /* POPAnimationEventInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EC9997571756A17B00A73F49 /* POPAnimationEventInternal.h */; };
+		ECA0D5C018D8196A003720DF /* UnitBezier.h in Headers */ = {isa = PBXBuildFile; fileRef = ECA0D5BF18D8196A003720DF /* UnitBezier.h */; };
+		ECA0D5C118D8196A003720DF /* UnitBezier.h in Headers */ = {isa = PBXBuildFile; fileRef = ECA0D5BF18D8196A003720DF /* UnitBezier.h */; };
+		ECA94D0D18ECAE82002E4CEB /* POP.h in Headers */ = {isa = PBXBuildFile; fileRef = ECA94D0B18ECAE82002E4CEB /* POP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECA94D0E18ECAE82002E4CEB /* POP.h in Headers */ = {isa = PBXBuildFile; fileRef = ECA94D0B18ECAE82002E4CEB /* POP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECCBC57217D96DBD00C69976 /* FloatConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = ECCBC57117D96DBD00C69976 /* FloatConversion.h */; };
+		ECD80F1118CFD2EF00AE4303 /* POPGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = ECD80F0F18CFD2EF00AE4303 /* POPGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECD80F1218CFD2EF00AE4303 /* POPGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = ECD80F0F18CFD2EF00AE4303 /* POPGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECD80F1318CFD2EF00AE4303 /* POPGeometry.mm in Sources */ = {isa = PBXBuildFile; fileRef = ECD80F1018CFD2EF00AE4303 /* POPGeometry.mm */; };
+		ECD80F1418CFD2EF00AE4303 /* POPGeometry.mm in Sources */ = {isa = PBXBuildFile; fileRef = ECD80F1018CFD2EF00AE4303 /* POPGeometry.mm */; };
+		ECDA0CC618C92BC900D14897 /* POPAnimatable.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC99974A17568DAD00A73F49 /* POPAnimatable.mm */; };
+		ECDA0CC718C92BD200D14897 /* POPBaseAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6F55A4175E6641008D995D /* POPBaseAnimationTests.mm */; };
+		ECDA0CC818C92BD200D14897 /* POPAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC191239162FB53A00E0CC76 /* POPAnimationTests.mm */; };
+		ECDA0CC918C92BD200D14897 /* POPAnimationMRRTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC3F125916FB728B00922E3A /* POPAnimationMRRTests.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		ECDA0CCA18C92BD200D14897 /* POPAnimationTestsExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC3F125C16FB78E800922E3A /* POPAnimationTestsExtras.mm */; };
+		ECDA0CCB18C92BD200D14897 /* POPAnimatablePropertyTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC91D51B16FCC45C00E22B47 /* POPAnimatablePropertyTests.mm */; };
+		ECDA0CCC18C92BD200D14897 /* POPDecayAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6F55A1175E654B008D995D /* POPDecayAnimationTests.mm */; };
+		ECDA0CCD18C92BD200D14897 /* POPSpringAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC6F55AA175E6B11008D995D /* POPSpringAnimationTests.mm */; };
+		ECDA0CCE18C92BD200D14897 /* POPEaseInEaseOutAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC7D2CFB1795AB3100E50A78 /* POPEaseInEaseOutAnimationTests.mm */; };
+		ECDA0CCF18C92C3E00D14897 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECC5A887162FBD6200F7F15C /* QuartzCore.framework */; };
+		ECDA0CD018C92C4C00D14897 /* libpop.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC191218162FB53A00E0CC76 /* libpop.a */; };
+		ECDA0CD118C92D3900D14897 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECC5A89D162FBD9B00F7F15C /* CoreGraphics.framework */; };
+		ECF01ED418C92B7F009E0AD1 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC19122A162FB53A00E0CC76 /* SenTestingKit.framework */; };
+		ECF01ED518C92B7F009E0AD1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC19121B162FB53A00E0CC76 /* Foundation.framework */; };
+		ECF01ED618C92B7F009E0AD1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECEED93D18C91ACF00DD95F2 /* UIKit.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		EC7E31A418C93D6600B38170 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EC19120F162FB53A00E0CC76 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EC68857E18C7B60000C6194C;
+			remoteInfo = "POP-OSX";
+		};
+		ECF01EE018C92B80009E0AD1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EC19120F162FB53A00E0CC76 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EC191217162FB53A00E0CC76;
+			remoteInfo = POP;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		EC191216162FB53A00E0CC76 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/${PRODUCT_NAME}";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		02E3EF56E92B403A9BF79E26 /* boost */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = boost; path = ../../Vendor/Boost/boost.framework/boost; sourceTree = SRCROOT; };
+		0B6BE74819FFD3B900762101 /* pop.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = pop.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B6BE7E619FFD98100762101 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
+		0BA2A8F219FFDC7F00B28783 /* DynamicLibrary-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "DynamicLibrary-iOS.xcconfig"; sourceTree = "<group>"; };
+		3606F0C22CF0EB387E8AC270 /* Pods-pop-tests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests.profile.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.profile.xcconfig"; sourceTree = "<group>"; };
+		403DCBBC1783F4A000793AE1 /* libFBWebP.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBWebP.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		408E6FF86BDD3F47FC44BF6A /* Pods-pop-tests.gcov.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests.gcov.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.gcov.xcconfig"; sourceTree = "<group>"; };
+		4F4245BFB89B6239FE145E69 /* Pods-pop-tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.debug.xcconfig"; sourceTree = "<group>"; };
+		5E17BB1E17457345009842B6 /* POPCustomAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPCustomAnimation.h; sourceTree = "<group>"; };
+		5E17BB1F17457345009842B6 /* POPCustomAnimation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPCustomAnimation.mm; sourceTree = "<group>"; };
+		669428F41A009B6A00A420B0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		669428F51A009B6A00A420B0 /* pop-embedded.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "pop-embedded.h"; sourceTree = "<group>"; };
+		68569BF4084F464294AFEBA1 /* libFBReachability.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		7628E8427F4090DD496F92B1 /* Pods-pop-tests-osx.gcov.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests-osx.gcov.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.gcov.xcconfig"; sourceTree = "<group>"; };
+		7BDD7D9C2D2C9AC55E295CD0 /* Pods-pop-tests-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.release.xcconfig"; sourceTree = "<group>"; };
+		7D469990AA7D05FB882F89FC /* Pods-pop-tests-osx.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests-osx.profile.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.profile.xcconfig"; sourceTree = "<group>"; };
+		90AA30B618988BBE00E3BDF7 /* POPSpringSolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPSpringSolver.h; sourceTree = "<group>"; };
+		9BBD2916A451976950B4C1F6 /* Pods-pop-tests-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx.debug.xcconfig"; sourceTree = "<group>"; };
+		B551F115E86E4C7CA0D92E78 /* libDoubleConversion.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libDoubleConversion.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD1A8D5BCA37415F86519334 /* libCAres.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libCAres.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C4E7267217CE4436805A912B /* libFBCoreDataKit.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBCoreDataKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5794B0CC3DBDE8D02CF112A /* Pods-pop-tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pop-tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests.release.xcconfig"; sourceTree = "<group>"; };
+		D075ECD10B62441CBB9A90F6 /* libPods-pop-tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-pop-tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D411892A480A401FB4D1AA07 /* libPods-pop-tests-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-pop-tests-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D52A06EC505A4B82B3BBD5E6 /* libEvent.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libEvent.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5D894724A104C729754ABCA /* libGLog.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libGLog.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC0AE12F16BC73CE001DA2CE /* POPAnimationExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationExtras.h; sourceTree = "<group>"; };
+		EC0AE13016BC73CE001DA2CE /* POPAnimationExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimationExtras.mm; sourceTree = "<group>"; };
+		EC191218162FB53A00E0CC76 /* libpop.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libpop.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC19121B162FB53A00E0CC76 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		EC19121F162FB53A00E0CC76 /* pop-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "pop-Prefix.pch"; path = "../pop/pop-Prefix.pch"; sourceTree = "<group>"; };
+		EC19122A162FB53A00E0CC76 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		EC19122C162FB53A00E0CC76 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		EC191239162FB53A00E0CC76 /* POPAnimationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimationTests.mm; sourceTree = "<group>"; };
+		EC191288162FB5B700E0CC76 /* POPAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimation.h; sourceTree = "<group>"; };
+		EC191289162FB5B700E0CC76 /* POPAnimation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimation.mm; sourceTree = "<group>"; };
+		EC19128A162FB5B700E0CC76 /* POPAnimationInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationInternal.h; sourceTree = "<group>"; };
+		EC19128B162FB5B700E0CC76 /* POPAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimator.h; sourceTree = "<group>"; };
+		EC19128C162FB5B700E0CC76 /* POPAnimator.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimator.mm; sourceTree = "<group>"; };
+		EC19128D162FB5B700E0CC76 /* POPAnimatorPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimatorPrivate.h; sourceTree = "<group>"; };
+		EC19128E162FB5B700E0CC76 /* POPAnimatableProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimatableProperty.h; sourceTree = "<group>"; };
+		EC19128F162FB5B700E0CC76 /* POPAnimatableProperty.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimatableProperty.mm; sourceTree = "<group>"; };
+		EC1CD94E18D80A5C00DE2649 /* POPAnimationPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationPrivate.h; sourceTree = "<group>"; };
+		EC35DB2618EE3E820023E077 /* POPAnimationTracer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationTracer.h; sourceTree = "<group>"; };
+		EC35DB2718EE3E820023E077 /* POPAnimationTracer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimationTracer.mm; sourceTree = "<group>"; };
+		EC35DB2818EE3E820023E077 /* POPAnimationTracerInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationTracerInternal.h; sourceTree = "<group>"; };
+		EC3F125916FB728B00922E3A /* POPAnimationMRRTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimationMRRTests.mm; sourceTree = "<group>"; };
+		EC3F125B16FB78E800922E3A /* POPAnimationTestsExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationTestsExtras.h; sourceTree = "<group>"; };
+		EC3F125C16FB78E800922E3A /* POPAnimationTestsExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimationTestsExtras.mm; sourceTree = "<group>"; };
+		EC6465CE1794B4660014176F /* POPMath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPMath.h; sourceTree = "<group>"; };
+		EC6465CF1794B4660014176F /* POPMath.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPMath.mm; sourceTree = "<group>"; };
+		EC67007018D3D89F00F7387F /* POPCGUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPCGUtils.h; sourceTree = "<group>"; };
+		EC67007118D3D89F00F7387F /* POPCGUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPCGUtils.mm; sourceTree = "<group>"; };
+		EC68857F18C7B60000C6194C /* pop.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = pop.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC68858018C7B60000C6194C /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		EC68858318C7B60000C6194C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		EC68858418C7B60000C6194C /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		EC68858518C7B60000C6194C /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		EC68858818C7B60000C6194C /* pop-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "pop-Info.plist"; sourceTree = "<group>"; };
+		EC68858A18C7B60000C6194C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		EC68858C18C7B60000C6194C /* pop-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "pop-Prefix.pch"; sourceTree = "<group>"; };
+		EC68859518C7B60100C6194C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		EC6885D318C7C44E00C6194C /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		EC6C098819141BBD00F8EA96 /* POPBasicAnimationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPBasicAnimationTests.mm; sourceTree = "<group>"; };
+		EC6F55A1175E654B008D995D /* POPDecayAnimationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPDecayAnimationTests.mm; sourceTree = "<group>"; };
+		EC6F55A3175E6641008D995D /* POPBaseAnimationTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPBaseAnimationTests.h; sourceTree = "<group>"; };
+		EC6F55A4175E6641008D995D /* POPBaseAnimationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPBaseAnimationTests.mm; sourceTree = "<group>"; };
+		EC6F55AA175E6B11008D995D /* POPSpringAnimationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPSpringAnimationTests.mm; sourceTree = "<group>"; };
+		EC70AC4218CCF4FC0067018C /* POPVector.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPVector.mm; sourceTree = "<group>"; };
+		EC70AC4318CCF4FC0067018C /* POPVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPVector.h; sourceTree = "<group>"; };
+		EC72875418E13348006EEE54 /* POPCustomAnimationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPCustomAnimationTests.mm; sourceTree = "<group>"; };
+		EC7D2CFB1795AB3100E50A78 /* POPEaseInEaseOutAnimationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPEaseInEaseOutAnimationTests.mm; sourceTree = "<group>"; };
+		EC7E319918C93D6500B38170 /* pop-tests-osx.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "pop-tests-osx.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC7E319D18C93D6500B38170 /* pop-tests-osx-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "pop-tests-osx-Info.plist"; sourceTree = "<group>"; };
+		EC7E319F18C93D6500B38170 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		EC7E31A318C93D6500B38170 /* pop-tests-OSX-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "pop-tests-OSX-Prefix.pch"; sourceTree = "<group>"; };
+		EC882A7718C91983007829CC /* pop-tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "pop-tests-Info.plist"; sourceTree = "<group>"; };
+		EC882A7918C91983007829CC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		EC882A7D18C91983007829CC /* pop-tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "pop-tests-Prefix.pch"; sourceTree = "<group>"; };
+		EC8F013E18FFBBD300DF8905 /* POPPropertyAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPPropertyAnimation.h; sourceTree = "<group>"; };
+		EC8F014418FFBC2D00DF8905 /* POPPropertyAnimationInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPPropertyAnimationInternal.h; sourceTree = "<group>"; };
+		EC8F014A18FFBC8200DF8905 /* POPPropertyAnimation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPPropertyAnimation.mm; sourceTree = "<group>"; };
+		EC8F014D18FFBD3E00DF8905 /* POPBasicAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPBasicAnimation.h; sourceTree = "<group>"; };
+		EC8F014E18FFBD3E00DF8905 /* POPBasicAnimation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPBasicAnimation.mm; sourceTree = "<group>"; };
+		EC8F015318FFBD5600DF8905 /* POPBasicAnimationInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPBasicAnimationInternal.h; sourceTree = "<group>"; };
+		EC8F015A18FFBE8C00DF8905 /* POPDecayAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPDecayAnimation.h; sourceTree = "<group>"; };
+		EC8F015B18FFBE8C00DF8905 /* POPDecayAnimation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPDecayAnimation.mm; sourceTree = "<group>"; };
+		EC8F016018FFBE9D00DF8905 /* POPDecayAnimationInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPDecayAnimationInternal.h; sourceTree = "<group>"; };
+		EC8F016618FFBEB500DF8905 /* POPSpringAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPSpringAnimation.h; sourceTree = "<group>"; };
+		EC8F016718FFBEB500DF8905 /* POPSpringAnimation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPSpringAnimation.mm; sourceTree = "<group>"; };
+		EC8F016C18FFBEC200DF8905 /* POPSpringAnimationInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPSpringAnimationInternal.h; sourceTree = "<group>"; };
+		EC91D51B16FCC45C00E22B47 /* POPAnimatablePropertyTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimatablePropertyTests.mm; sourceTree = "<group>"; };
+		EC91E95F18C00EC90025B8AD /* POPDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPDefines.h; sourceTree = "<group>"; };
+		EC91E96D18C014DE0025B8AD /* POPAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAction.h; sourceTree = "<group>"; };
+		EC94B07717D95447003CE2C8 /* TransformationMatrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TransformationMatrix.cpp; path = WebCore/TransformationMatrix.cpp; sourceTree = "<group>"; };
+		EC94B07817D95447003CE2C8 /* TransformationMatrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TransformationMatrix.h; path = WebCore/TransformationMatrix.h; sourceTree = "<group>"; };
+		EC94B07B17D95CAA003CE2C8 /* POPLayerExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPLayerExtras.h; sourceTree = "<group>"; };
+		EC94B07C17D95CAA003CE2C8 /* POPLayerExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPLayerExtras.mm; sourceTree = "<group>"; };
+		EC95538E1743E278001E6AF2 /* POPAnimationRuntime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationRuntime.h; sourceTree = "<group>"; };
+		EC95538F1743E278001E6AF2 /* POPAnimationRuntime.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimationRuntime.mm; sourceTree = "<group>"; };
+		EC99974917568DAD00A73F49 /* POPAnimatable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = POPAnimatable.h; path = "pop-tests/POPAnimatable.h"; sourceTree = SOURCE_ROOT; };
+		EC99974A17568DAD00A73F49 /* POPAnimatable.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = POPAnimatable.mm; path = "pop-tests/POPAnimatable.mm"; sourceTree = SOURCE_ROOT; };
+		EC9997531756A0C300A73F49 /* POPAnimationEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationEvent.h; sourceTree = "<group>"; };
+		EC9997541756A0C300A73F49 /* POPAnimationEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPAnimationEvent.mm; sourceTree = "<group>"; };
+		EC9997571756A17B00A73F49 /* POPAnimationEventInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimationEventInternal.h; sourceTree = "<group>"; };
+		ECA0D5BF18D8196A003720DF /* UnitBezier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UnitBezier.h; path = WebCore/UnitBezier.h; sourceTree = "<group>"; };
+		ECA94D0B18ECAE82002E4CEB /* POP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = POP.h; path = pop/POP.h; sourceTree = SOURCE_ROOT; };
+		ECADA2A416A8A99E00A20182 /* libMessagePack.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libMessagePack.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECADA2A516A8A99E00A20182 /* libSPDY.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSPDY.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECC1DB0918CA291B008C7DEA /* Application-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Application-iOS.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB0A18CA291B008C7DEA /* Application-OSX.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Application-OSX.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB0B18CA291B008C7DEA /* Base-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-iOS.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB0C18CA291B008C7DEA /* Base-OSX.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-OSX.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB0E18CA291B008C7DEA /* Compiler.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Compiler.xcconfig; sourceTree = "<group>"; };
+		ECC1DB0F18CA291B008C7DEA /* iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = iOS.xcconfig; sourceTree = "<group>"; };
+		ECC1DB1018CA291B008C7DEA /* OSX.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = OSX.xcconfig; sourceTree = "<group>"; };
+		ECC1DB1218CA291B008C7DEA /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB1318CA291B008C7DEA /* Project-GCOV.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-GCOV.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB1618CA291B008C7DEA /* Project-Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Profile.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB1718CA291B008C7DEA /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB1818CA291B008C7DEA /* Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
+		ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StaticLibrary-iOS.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB1B18CA291B008C7DEA /* StaticLibrary-OSX.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StaticLibrary-OSX.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB1D18CA291B008C7DEA /* ApplicationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ApplicationTests.xcconfig; sourceTree = "<group>"; };
+		ECC1DB1E18CA291B008C7DEA /* LogicTests-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LogicTests-iOS.xcconfig"; sourceTree = "<group>"; };
+		ECC1DB1F18CA291B008C7DEA /* LogicTests-OSX.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LogicTests-OSX.xcconfig"; sourceTree = "<group>"; };
+		ECC5A887162FBD6200F7F15C /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		ECC5A889162FBD7600F7F15C /* libFBAnalytics.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBAnalytics.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECC5A88B162FBD7600F7F15C /* libFBFoundation.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBFoundation.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECC5A88C162FBD7600F7F15C /* libFBProvider.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBProvider.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECC5A88D162FBD7600F7F15C /* libFBTest.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBTest.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECC5A88F162FBD7600F7F15C /* libOCMock.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECC5A897162FBD8700F7F15C /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
+		ECC5A899162FBD8E00F7F15C /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		ECC5A89B162FBD9500F7F15C /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		ECC5A89D162FBD9B00F7F15C /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		ECC5A89F162FBDA400F7F15C /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		ECC5A8A1162FBDAB00F7F15C /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		ECC5A8A3162FBDC400F7F15C /* Accounts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accounts.framework; path = System/Library/Frameworks/Accounts.framework; sourceTree = SDKROOT; };
+		ECC5A8A5162FBDCA00F7F15C /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		ECC5A8A7162FBDCF00F7F15C /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		ECC5A8A9162FBDD800F7F15C /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		ECC5A8AB162FBDE100F7F15C /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
+		ECC5A8AD162FBDEB00F7F15C /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
+		ECC5A8AF162FBDF600F7F15C /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
+		ECC5A8B1162FBE0400F7F15C /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
+		ECC5A8B3162FBE0900F7F15C /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = usr/lib/libicucore.dylib; sourceTree = SDKROOT; };
+		ECC5A8B5162FBE1600F7F15C /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
+		ECC5A8B7162FBE1B00F7F15C /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		ECC5A8BA162FBF3A00F7F15C /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
+		ECC63411C31441ECAC3F5559 /* libLiger.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libLiger.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECCBC57117D96DBD00C69976 /* FloatConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FloatConversion.h; path = WebCore/FloatConversion.h; sourceTree = "<group>"; };
+		ECD80F0F18CFD2EF00AE4303 /* POPGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPGeometry.h; sourceTree = "<group>"; };
+		ECD80F1018CFD2EF00AE4303 /* POPGeometry.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPGeometry.mm; sourceTree = "<group>"; };
+		ECED421816F7D1FD00FFBEAC /* libFBNetworker.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFBNetworker.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECEED93A18C91AB600DD95F2 /* libOCMock.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECEED93D18C91ACF00DD95F2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		ECF01ED318C92B7F009E0AD1 /* pop-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "pop-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0B6BE74419FFD3B900762101 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC191215162FB53A00E0CC76 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC19121C162FB53A00E0CC76 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC68857B18C7B60000C6194C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC6885D418C7C44E00C6194C /* QuartzCore.framework in Frameworks */,
+				EC68858118C7B60000C6194C /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC7E319618C93D6500B38170 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC7E31B518C9422F00B38170 /* pop.framework in Frameworks */,
+				EC7E31B418C9422600B38170 /* QuartzCore.framework in Frameworks */,
+				EC7E319A18C93D6500B38170 /* SenTestingKit.framework in Frameworks */,
+				ADE1BB0636F940EC8EA7EE57 /* libPods-pop-tests-osx.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECF01ED018C92B7F009E0AD1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECDA0CD118C92D3900D14897 /* CoreGraphics.framework in Frameworks */,
+				ECDA0CD018C92C4C00D14897 /* libpop.a in Frameworks */,
+				ECDA0CCF18C92C3E00D14897 /* QuartzCore.framework in Frameworks */,
+				ECF01ED418C92B7F009E0AD1 /* SenTestingKit.framework in Frameworks */,
+				ECF01ED618C92B7F009E0AD1 /* UIKit.framework in Frameworks */,
+				ECF01ED518C92B7F009E0AD1 /* Foundation.framework in Frameworks */,
+				BFD8EB4ECB184EF99C22123A /* libPods-pop-tests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0BA2A8F119FFDC7F00B28783 /* Dynamic Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				0BA2A8F219FFDC7F00B28783 /* DynamicLibrary-iOS.xcconfig */,
+			);
+			path = "Dynamic Libraries";
+			sourceTree = "<group>";
+		};
+		4372557D5165714123EC6D70 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4F4245BFB89B6239FE145E69 /* Pods-pop-tests.debug.xcconfig */,
+				408E6FF86BDD3F47FC44BF6A /* Pods-pop-tests.gcov.xcconfig */,
+				C5794B0CC3DBDE8D02CF112A /* Pods-pop-tests.release.xcconfig */,
+				3606F0C22CF0EB387E8AC270 /* Pods-pop-tests.profile.xcconfig */,
+				9BBD2916A451976950B4C1F6 /* Pods-pop-tests-osx.debug.xcconfig */,
+				7628E8427F4090DD496F92B1 /* Pods-pop-tests-osx.gcov.xcconfig */,
+				7BDD7D9C2D2C9AC55E295CD0 /* Pods-pop-tests-osx.release.xcconfig */,
+				7D469990AA7D05FB882F89FC /* Pods-pop-tests-osx.profile.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		669428F31A009B6A00A420B0 /* pop-embedded */ = {
+			isa = PBXGroup;
+			children = (
+				669428F41A009B6A00A420B0 /* Info.plist */,
+				669428F51A009B6A00A420B0 /* pop-embedded.h */,
+			);
+			path = "pop-embedded";
+			sourceTree = SOURCE_ROOT;
+		};
+		EC19120D162FB53A00E0CC76 = {
+			isa = PBXGroup;
+			children = (
+				EC19121D162FB53A00E0CC76 /* pop */,
+				669428F31A009B6A00A420B0 /* pop-embedded */,
+				EC882A7518C91983007829CC /* pop-tests */,
+				ECC1DB0718CA291B008C7DEA /* Configuration */,
+				EC19121A162FB53A00E0CC76 /* Frameworks */,
+				EC191219162FB53A00E0CC76 /* Products */,
+				4372557D5165714123EC6D70 /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		EC191219162FB53A00E0CC76 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EC191218162FB53A00E0CC76 /* libpop.a */,
+				EC68857F18C7B60000C6194C /* pop.framework */,
+				ECF01ED318C92B7F009E0AD1 /* pop-tests.xctest */,
+				EC7E319918C93D6500B38170 /* pop-tests-osx.xctest */,
+				0B6BE74819FFD3B900762101 /* pop.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		EC19121A162FB53A00E0CC76 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0B6BE7E619FFD98100762101 /* CoreImage.framework */,
+				ECEED93D18C91ACF00DD95F2 /* UIKit.framework */,
+				ECEED93A18C91AB600DD95F2 /* libOCMock.a */,
+				EC6885D318C7C44E00C6194C /* QuartzCore.framework */,
+				403DCBBC1783F4A000793AE1 /* libFBWebP.a */,
+				ECED421816F7D1FD00FFBEAC /* libFBNetworker.a */,
+				68569BF4084F464294AFEBA1 /* libFBReachability.a */,
+				ECADA2A416A8A99E00A20182 /* libMessagePack.a */,
+				ECADA2A516A8A99E00A20182 /* libSPDY.a */,
+				ECC5A8BA162FBF3A00F7F15C /* AdSupport.framework */,
+				ECC5A8B7162FBE1B00F7F15C /* Security.framework */,
+				ECC5A8B5162FBE1600F7F15C /* AssetsLibrary.framework */,
+				ECC5A8B3162FBE0900F7F15C /* libicucore.dylib */,
+				ECC5A8B1162FBE0400F7F15C /* libz.dylib */,
+				ECC5A8AF162FBDF600F7F15C /* CoreTelephony.framework */,
+				ECC5A8AD162FBDEB00F7F15C /* CoreText.framework */,
+				ECC5A8AB162FBDE100F7F15C /* ImageIO.framework */,
+				ECC5A8A9162FBDD800F7F15C /* SystemConfiguration.framework */,
+				ECC5A8A7162FBDCF00F7F15C /* CoreLocation.framework */,
+				ECC5A8A5162FBDCA00F7F15C /* AVFoundation.framework */,
+				ECC5A8A3162FBDC400F7F15C /* Accounts.framework */,
+				ECC5A8A1162FBDAB00F7F15C /* MobileCoreServices.framework */,
+				ECC5A89F162FBDA400F7F15C /* CoreData.framework */,
+				ECC5A89D162FBD9B00F7F15C /* CoreGraphics.framework */,
+				ECC5A89B162FBD9500F7F15C /* AudioToolbox.framework */,
+				ECC5A899162FBD8E00F7F15C /* CFNetwork.framework */,
+				ECC5A897162FBD8700F7F15C /* AddressBook.framework */,
+				ECC5A889162FBD7600F7F15C /* libFBAnalytics.a */,
+				ECC5A88B162FBD7600F7F15C /* libFBFoundation.a */,
+				C4E7267217CE4436805A912B /* libFBCoreDataKit.a */,
+				ECC5A88C162FBD7600F7F15C /* libFBProvider.a */,
+				ECC5A88D162FBD7600F7F15C /* libFBTest.a */,
+				ECC5A88F162FBD7600F7F15C /* libOCMock.a */,
+				ECC5A887162FBD6200F7F15C /* QuartzCore.framework */,
+				EC19121B162FB53A00E0CC76 /* Foundation.framework */,
+				EC19122A162FB53A00E0CC76 /* SenTestingKit.framework */,
+				EC19122C162FB53A00E0CC76 /* UIKit.framework */,
+				E5D894724A104C729754ABCA /* libGLog.a */,
+				B551F115E86E4C7CA0D92E78 /* libDoubleConversion.a */,
+				D52A06EC505A4B82B3BBD5E6 /* libEvent.a */,
+				BD1A8D5BCA37415F86519334 /* libCAres.a */,
+				ECC63411C31441ECAC3F5559 /* libLiger.a */,
+				02E3EF56E92B403A9BF79E26 /* boost */,
+				EC68858018C7B60000C6194C /* Cocoa.framework */,
+				EC68859518C7B60100C6194C /* XCTest.framework */,
+				EC68858218C7B60000C6194C /* Other Frameworks */,
+				D075ECD10B62441CBB9A90F6 /* libPods-pop-tests.a */,
+				D411892A480A401FB4D1AA07 /* libPods-pop-tests-osx.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EC19121D162FB53A00E0CC76 /* pop */ = {
+			isa = PBXGroup;
+			children = (
+				EC8F015918FFBD7A00DF8905 /* Animations */,
+				EC8F017318FFC4CB00DF8905 /* Engine */,
+				EC8F017218FFC44800DF8905 /* Utility */,
+				ECA0D5BE18D818C3003720DF /* WebCore */,
+				EC6885AF18C7BCA400C6194C /* iOS Supporting Files */,
+				EC68858618C7B60000C6194C /* OSX Supporting Files */,
+				ECA94D0B18ECAE82002E4CEB /* POP.h */,
+			);
+			path = pop;
+			sourceTree = "<group>";
+		};
+		EC68858218C7B60000C6194C /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EC68858318C7B60000C6194C /* Foundation.framework */,
+				EC68858418C7B60000C6194C /* CoreData.framework */,
+				EC68858518C7B60000C6194C /* AppKit.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		EC68858618C7B60000C6194C /* OSX Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				EC68858818C7B60000C6194C /* pop-Info.plist */,
+				EC68858918C7B60000C6194C /* InfoPlist.strings */,
+				EC68858C18C7B60000C6194C /* pop-Prefix.pch */,
+			);
+			name = "OSX Supporting Files";
+			sourceTree = "<group>";
+		};
+		EC6885AF18C7BCA400C6194C /* iOS Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				EC19121F162FB53A00E0CC76 /* pop-Prefix.pch */,
+			);
+			name = "iOS Supporting Files";
+			path = "pop-tests";
+			sourceTree = SOURCE_ROOT;
+		};
+		EC7E319C18C93D6500B38170 /* Supporting Files - OSX */ = {
+			isa = PBXGroup;
+			children = (
+				EC7E319D18C93D6500B38170 /* pop-tests-osx-Info.plist */,
+				EC7E319E18C93D6500B38170 /* InfoPlist.strings */,
+				EC7E31A318C93D6500B38170 /* pop-tests-OSX-Prefix.pch */,
+			);
+			name = "Supporting Files - OSX";
+			path = "pop-tests-osx";
+			sourceTree = SOURCE_ROOT;
+		};
+		EC882A7518C91983007829CC /* pop-tests */ = {
+			isa = PBXGroup;
+			children = (
+				EC99974917568DAD00A73F49 /* POPAnimatable.h */,
+				EC99974A17568DAD00A73F49 /* POPAnimatable.mm */,
+				EC6F55A3175E6641008D995D /* POPBaseAnimationTests.h */,
+				EC6F55A4175E6641008D995D /* POPBaseAnimationTests.mm */,
+				EC191239162FB53A00E0CC76 /* POPAnimationTests.mm */,
+				EC3F125916FB728B00922E3A /* POPAnimationMRRTests.mm */,
+				EC3F125B16FB78E800922E3A /* POPAnimationTestsExtras.h */,
+				EC3F125C16FB78E800922E3A /* POPAnimationTestsExtras.mm */,
+				EC91D51B16FCC45C00E22B47 /* POPAnimatablePropertyTests.mm */,
+				EC6F55A1175E654B008D995D /* POPDecayAnimationTests.mm */,
+				EC6F55AA175E6B11008D995D /* POPSpringAnimationTests.mm */,
+				EC7D2CFB1795AB3100E50A78 /* POPEaseInEaseOutAnimationTests.mm */,
+				EC72875418E13348006EEE54 /* POPCustomAnimationTests.mm */,
+				EC6C098819141BBD00F8EA96 /* POPBasicAnimationTests.mm */,
+				EC7E319C18C93D6500B38170 /* Supporting Files - OSX */,
+				EC882A7618C91983007829CC /* Supporting Files - iOS */,
+			);
+			path = "pop-tests";
+			sourceTree = "<group>";
+		};
+		EC882A7618C91983007829CC /* Supporting Files - iOS */ = {
+			isa = PBXGroup;
+			children = (
+				EC882A7718C91983007829CC /* pop-tests-Info.plist */,
+				EC882A7818C91983007829CC /* InfoPlist.strings */,
+				EC882A7D18C91983007829CC /* pop-tests-Prefix.pch */,
+			);
+			name = "Supporting Files - iOS";
+			sourceTree = "<group>";
+		};
+		EC8F015918FFBD7A00DF8905 /* Animations */ = {
+			isa = PBXGroup;
+			children = (
+				EC191288162FB5B700E0CC76 /* POPAnimation.h */,
+				EC191289162FB5B700E0CC76 /* POPAnimation.mm */,
+				EC19128A162FB5B700E0CC76 /* POPAnimationInternal.h */,
+				EC1CD94E18D80A5C00DE2649 /* POPAnimationPrivate.h */,
+				EC8F013E18FFBBD300DF8905 /* POPPropertyAnimation.h */,
+				EC8F014A18FFBC8200DF8905 /* POPPropertyAnimation.mm */,
+				EC8F014418FFBC2D00DF8905 /* POPPropertyAnimationInternal.h */,
+				EC8F014D18FFBD3E00DF8905 /* POPBasicAnimation.h */,
+				EC8F014E18FFBD3E00DF8905 /* POPBasicAnimation.mm */,
+				EC8F015318FFBD5600DF8905 /* POPBasicAnimationInternal.h */,
+				5E17BB1E17457345009842B6 /* POPCustomAnimation.h */,
+				5E17BB1F17457345009842B6 /* POPCustomAnimation.mm */,
+				EC8F015A18FFBE8C00DF8905 /* POPDecayAnimation.h */,
+				EC8F015B18FFBE8C00DF8905 /* POPDecayAnimation.mm */,
+				EC8F016018FFBE9D00DF8905 /* POPDecayAnimationInternal.h */,
+				EC8F016618FFBEB500DF8905 /* POPSpringAnimation.h */,
+				EC8F016718FFBEB500DF8905 /* POPSpringAnimation.mm */,
+				EC8F016C18FFBEC200DF8905 /* POPSpringAnimationInternal.h */,
+			);
+			name = Animations;
+			sourceTree = "<group>";
+		};
+		EC8F017218FFC44800DF8905 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				EC91E96D18C014DE0025B8AD /* POPAction.h */,
+				EC67007018D3D89F00F7387F /* POPCGUtils.h */,
+				EC67007118D3D89F00F7387F /* POPCGUtils.mm */,
+				EC91E95F18C00EC90025B8AD /* POPDefines.h */,
+				ECD80F0F18CFD2EF00AE4303 /* POPGeometry.h */,
+				ECD80F1018CFD2EF00AE4303 /* POPGeometry.mm */,
+				EC94B07B17D95CAA003CE2C8 /* POPLayerExtras.h */,
+				EC94B07C17D95CAA003CE2C8 /* POPLayerExtras.mm */,
+				EC6465CE1794B4660014176F /* POPMath.h */,
+				EC6465CF1794B4660014176F /* POPMath.mm */,
+				90AA30B618988BBE00E3BDF7 /* POPSpringSolver.h */,
+				EC70AC4318CCF4FC0067018C /* POPVector.h */,
+				EC70AC4218CCF4FC0067018C /* POPVector.mm */,
+			);
+			name = Utility;
+			sourceTree = "<group>";
+		};
+		EC8F017318FFC4CB00DF8905 /* Engine */ = {
+			isa = PBXGroup;
+			children = (
+				EC19128E162FB5B700E0CC76 /* POPAnimatableProperty.h */,
+				EC19128F162FB5B700E0CC76 /* POPAnimatableProperty.mm */,
+				EC9997531756A0C300A73F49 /* POPAnimationEvent.h */,
+				EC9997541756A0C300A73F49 /* POPAnimationEvent.mm */,
+				EC9997571756A17B00A73F49 /* POPAnimationEventInternal.h */,
+				EC0AE12F16BC73CE001DA2CE /* POPAnimationExtras.h */,
+				EC0AE13016BC73CE001DA2CE /* POPAnimationExtras.mm */,
+				EC95538E1743E278001E6AF2 /* POPAnimationRuntime.h */,
+				EC95538F1743E278001E6AF2 /* POPAnimationRuntime.mm */,
+				EC35DB2618EE3E820023E077 /* POPAnimationTracer.h */,
+				EC35DB2718EE3E820023E077 /* POPAnimationTracer.mm */,
+				EC35DB2818EE3E820023E077 /* POPAnimationTracerInternal.h */,
+				EC19128B162FB5B700E0CC76 /* POPAnimator.h */,
+				EC19128C162FB5B700E0CC76 /* POPAnimator.mm */,
+				EC19128D162FB5B700E0CC76 /* POPAnimatorPrivate.h */,
+			);
+			name = Engine;
+			sourceTree = "<group>";
+		};
+		ECA0D5BE18D818C3003720DF /* WebCore */ = {
+			isa = PBXGroup;
+			children = (
+				ECCBC57117D96DBD00C69976 /* FloatConversion.h */,
+				EC94B07817D95447003CE2C8 /* TransformationMatrix.h */,
+				EC94B07717D95447003CE2C8 /* TransformationMatrix.cpp */,
+				ECA0D5BF18D8196A003720DF /* UnitBezier.h */,
+			);
+			name = WebCore;
+			sourceTree = "<group>";
+		};
+		ECC1DB0718CA291B008C7DEA /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				ECC1DB0818CA291B008C7DEA /* Applications */,
+				ECC1DB0B18CA291B008C7DEA /* Base-iOS.xcconfig */,
+				ECC1DB0C18CA291B008C7DEA /* Base-OSX.xcconfig */,
+				0BA2A8F119FFDC7F00B28783 /* Dynamic Libraries */,
+				ECC1DB0D18CA291B008C7DEA /* Platform */,
+				ECC1DB1118CA291B008C7DEA /* Projects */,
+				ECC1DB1918CA291B008C7DEA /* Static Libraries */,
+				ECC1DB1C18CA291B008C7DEA /* Tests */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		ECC1DB0818CA291B008C7DEA /* Applications */ = {
+			isa = PBXGroup;
+			children = (
+				ECC1DB0918CA291B008C7DEA /* Application-iOS.xcconfig */,
+				ECC1DB0A18CA291B008C7DEA /* Application-OSX.xcconfig */,
+			);
+			path = Applications;
+			sourceTree = "<group>";
+		};
+		ECC1DB0D18CA291B008C7DEA /* Platform */ = {
+			isa = PBXGroup;
+			children = (
+				ECC1DB0E18CA291B008C7DEA /* Compiler.xcconfig */,
+				ECC1DB0F18CA291B008C7DEA /* iOS.xcconfig */,
+				ECC1DB1018CA291B008C7DEA /* OSX.xcconfig */,
+			);
+			path = Platform;
+			sourceTree = "<group>";
+		};
+		ECC1DB1118CA291B008C7DEA /* Projects */ = {
+			isa = PBXGroup;
+			children = (
+				ECC1DB1218CA291B008C7DEA /* Project-Debug.xcconfig */,
+				ECC1DB1318CA291B008C7DEA /* Project-GCOV.xcconfig */,
+				ECC1DB1618CA291B008C7DEA /* Project-Profile.xcconfig */,
+				ECC1DB1718CA291B008C7DEA /* Project-Release.xcconfig */,
+				ECC1DB1818CA291B008C7DEA /* Project.xcconfig */,
+			);
+			path = Projects;
+			sourceTree = "<group>";
+		};
+		ECC1DB1918CA291B008C7DEA /* Static Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */,
+				ECC1DB1B18CA291B008C7DEA /* StaticLibrary-OSX.xcconfig */,
+			);
+			path = "Static Libraries";
+			sourceTree = "<group>";
+		};
+		ECC1DB1C18CA291B008C7DEA /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				ECC1DB1D18CA291B008C7DEA /* ApplicationTests.xcconfig */,
+				ECC1DB1E18CA291B008C7DEA /* LogicTests-iOS.xcconfig */,
+				ECC1DB1F18CA291B008C7DEA /* LogicTests-OSX.xcconfig */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0B6BE74519FFD3B900762101 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B6BE77819FFD4AB00762101 /* POPGeometry.h in Headers */,
+				0B6BE77719FFD4A300762101 /* POPAnimationPrivate.h in Headers */,
+				0B6BE77619FFD49A00762101 /* POPAnimation.h in Headers */,
+				0B6BE77519FFD49100762101 /* POPAnimator.h in Headers */,
+				0B6BE77419FFD48700762101 /* POPAnimatableProperty.h in Headers */,
+				0B6BE77319FFD47F00762101 /* POPBasicAnimation.h in Headers */,
+				0B6BE77219FFD47800762101 /* POPPropertyAnimation.h in Headers */,
+				0B6BE77119FFD46F00762101 /* POPAnimatorPrivate.h in Headers */,
+				0B6BE77019FFD46600762101 /* POPLayerExtras.h in Headers */,
+				0B6BE76F19FFD44000762101 /* POPSpringAnimation.h in Headers */,
+				0B6BE76E19FFD43800762101 /* POPCustomAnimation.h in Headers */,
+				0B6BE76D19FFD42700762101 /* POPAnimationExtras.h in Headers */,
+				0B6BE76C19FFD41D00762101 /* POPDecayAnimation.h in Headers */,
+				0B6BE76B19FFD41500762101 /* POPDefines.h in Headers */,
+				669428F71A009B6A00A420B0 /* pop-embedded.h in Headers */,
+				0B6BE76A19FFD41100762101 /* POPAnimationEvent.h in Headers */,
+				0B6BE76919FFD40700762101 /* POP.h in Headers */,
+				0B6BE76819FFD3FF00762101 /* POPAnimationTracer.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC191294162FB5DD00E0CC76 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECD80F1118CFD2EF00AE4303 /* POPGeometry.h in Headers */,
+				EC1CD95018D80A5C00DE2649 /* POPAnimationPrivate.h in Headers */,
+				EC191295162FB5EC00E0CC76 /* POPAnimation.h in Headers */,
+				EC191297162FB5EC00E0CC76 /* POPAnimator.h in Headers */,
+				EC35DB2D18EE3E820023E077 /* POPAnimationTracerInternal.h in Headers */,
+				EC191299162FB5EC00E0CC76 /* POPAnimatableProperty.h in Headers */,
+				EC8F014F18FFBD3E00DF8905 /* POPBasicAnimation.h in Headers */,
+				EC8F014018FFBBD300DF8905 /* POPPropertyAnimation.h in Headers */,
+				EC191296162FB5EC00E0CC76 /* POPAnimationInternal.h in Headers */,
+				EC191298162FB5EC00E0CC76 /* POPAnimatorPrivate.h in Headers */,
+				ECCBC57217D96DBD00C69976 /* FloatConversion.h in Headers */,
+				EC94B07D17D95CAA003CE2C8 /* POPLayerExtras.h in Headers */,
+				EC8F016818FFBEB500DF8905 /* POPSpringAnimation.h in Headers */,
+				5E17BB2017457345009842B6 /* POPCustomAnimation.h in Headers */,
+				EC67007218D3D89F00F7387F /* POPCGUtils.h in Headers */,
+				EC8F016218FFBE9D00DF8905 /* POPDecayAnimationInternal.h in Headers */,
+				EC0AE13116BC73CE001DA2CE /* POPAnimationExtras.h in Headers */,
+				EC91E96E18C014DE0025B8AD /* POPAction.h in Headers */,
+				90AA30B718988BBE00E3BDF7 /* POPSpringSolver.h in Headers */,
+				EC8F014618FFBC2D00DF8905 /* POPPropertyAnimationInternal.h in Headers */,
+				EC8F015C18FFBE8C00DF8905 /* POPDecayAnimation.h in Headers */,
+				EC91E96018C00EC90025B8AD /* POPDefines.h in Headers */,
+				EC70AC4618CCF4FC0067018C /* POPVector.h in Headers */,
+				EC9553901743E278001E6AF2 /* POPAnimationRuntime.h in Headers */,
+				EC6465D01794B4660014176F /* POPMath.h in Headers */,
+				EC8F016E18FFBEC200DF8905 /* POPSpringAnimationInternal.h in Headers */,
+				EC9997551756A0C300A73F49 /* POPAnimationEvent.h in Headers */,
+				ECA94D0D18ECAE82002E4CEB /* POP.h in Headers */,
+				EC9997591756A17B00A73F49 /* POPAnimationEventInternal.h in Headers */,
+				EC94B07A17D95447003CE2C8 /* TransformationMatrix.h in Headers */,
+				EC8F015518FFBD5600DF8905 /* POPBasicAnimationInternal.h in Headers */,
+				EC35DB2918EE3E820023E077 /* POPAnimationTracer.h in Headers */,
+				ECA0D5C018D8196A003720DF /* UnitBezier.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC68857C18C7B60000C6194C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECD80F1218CFD2EF00AE4303 /* POPGeometry.h in Headers */,
+				EC1CD95118D80A5C00DE2649 /* POPAnimationPrivate.h in Headers */,
+				EC6885D118C7BD8500C6194C /* TransformationMatrix.h in Headers */,
+				EC6885B718C7BD2600C6194C /* POPAnimationEventInternal.h in Headers */,
+				EC35DB2E18EE3E820023E077 /* POPAnimationTracerInternal.h in Headers */,
+				EC6885C818C7BD5F00C6194C /* POPLayerExtras.h in Headers */,
+				EC8F015018FFBD3E00DF8905 /* POPBasicAnimation.h in Headers */,
+				EC8F014118FFBBD300DF8905 /* POPPropertyAnimation.h in Headers */,
+				EC6885BB18C7BD3700C6194C /* POPMath.h in Headers */,
+				EC6885C418C7BD5100C6194C /* POPAnimatorPrivate.h in Headers */,
+				EC6885C518C7BD5500C6194C /* POPCustomAnimation.h in Headers */,
+				EC6885CA18C7BD6500C6194C /* FloatConversion.h in Headers */,
+				EC8F016918FFBEB500DF8905 /* POPSpringAnimation.h in Headers */,
+				EC67007318D3D89F00F7387F /* POPCGUtils.h in Headers */,
+				EC6885B318C7BD1500C6194C /* POPAnimation.h in Headers */,
+				EC8F016318FFBE9D00DF8905 /* POPDecayAnimationInternal.h in Headers */,
+				EC6885CF18C7BD7B00C6194C /* POPDefines.h in Headers */,
+				EC6885D018C7BD7F00C6194C /* POPAction.h in Headers */,
+				EC70AC4718CCF4FC0067018C /* POPVector.h in Headers */,
+				EC8F014718FFBC2D00DF8905 /* POPPropertyAnimationInternal.h in Headers */,
+				EC8F015D18FFBE8C00DF8905 /* POPDecayAnimation.h in Headers */,
+				EC6885BA18C7BD3400C6194C /* POPAnimationInternal.h in Headers */,
+				EC6885B518C7BD1C00C6194C /* POPAnimationEvent.h in Headers */,
+				EC6885B818C7BD2B00C6194C /* POPAnimationExtras.h in Headers */,
+				ECA94D0E18ECAE82002E4CEB /* POP.h in Headers */,
+				EC8F016F18FFBEC200DF8905 /* POPSpringAnimationInternal.h in Headers */,
+				EC6885C718C7BD5C00C6194C /* POPSpringSolver.h in Headers */,
+				EC6885C218C7BD4B00C6194C /* POPAnimator.h in Headers */,
+				EC6885B018C7BD0A00C6194C /* POPAnimatableProperty.h in Headers */,
+				ECA0D5C118D8196A003720DF /* UnitBezier.h in Headers */,
+				EC8F015618FFBD5600DF8905 /* POPBasicAnimationInternal.h in Headers */,
+				EC35DB2A18EE3E820023E077 /* POPAnimationTracer.h in Headers */,
+				EC6885BD18C7BD3E00C6194C /* POPAnimationRuntime.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		0B6BE74719FFD3B900762101 /* pop-embedded */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0B6BE75B19FFD3B900762101 /* Build configuration list for PBXNativeTarget "pop-embedded" */;
+			buildPhases = (
+				0B6BE74319FFD3B900762101 /* Sources */,
+				0B6BE74419FFD3B900762101 /* Frameworks */,
+				0B6BE74519FFD3B900762101 /* Headers */,
+				0B6BE74619FFD3B900762101 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "pop-embedded";
+			productName = "pop-ios";
+			productReference = 0B6BE74819FFD3B900762101 /* pop.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		EC191217162FB53A00E0CC76 /* pop */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EC19123D162FB53A00E0CC76 /* Build configuration list for PBXNativeTarget "pop" */;
+			buildPhases = (
+				EC191214162FB53A00E0CC76 /* Sources */,
+				EC191215162FB53A00E0CC76 /* Frameworks */,
+				EC191216162FB53A00E0CC76 /* CopyFiles */,
+				EC191294162FB5DD00E0CC76 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = pop;
+			productName = POP;
+			productReference = EC191218162FB53A00E0CC76 /* libpop.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		EC68857E18C7B60000C6194C /* pop-osx */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EC6885A318C7B60100C6194C /* Build configuration list for PBXNativeTarget "pop-osx" */;
+			buildPhases = (
+				EC68857A18C7B60000C6194C /* Sources */,
+				EC68857B18C7B60000C6194C /* Frameworks */,
+				EC68857C18C7B60000C6194C /* Headers */,
+				EC68857D18C7B60000C6194C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "pop-osx";
+			productName = POP;
+			productReference = EC68857F18C7B60000C6194C /* pop.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		EC7E319818C93D6500B38170 /* pop-tests-osx */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EC7E31A618C93D6600B38170 /* Build configuration list for PBXNativeTarget "pop-tests-osx" */;
+			buildPhases = (
+				2F7E04AE9A5B41869AF78DA9 /* Check Pods Manifest.lock */,
+				EC7E319518C93D6500B38170 /* Sources */,
+				EC7E319618C93D6500B38170 /* Frameworks */,
+				EC7E319718C93D6500B38170 /* Resources */,
+				063BFBF07EAD4D74B19E2BC0 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EC7E31A518C93D6600B38170 /* PBXTargetDependency */,
+			);
+			name = "pop-tests-osx";
+			productName = "pop-tests-osx";
+			productReference = EC7E319918C93D6500B38170 /* pop-tests-osx.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		ECF01ED218C92B7F009E0AD1 /* pop-tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECF01EE218C92B80009E0AD1 /* Build configuration list for PBXNativeTarget "pop-tests" */;
+			buildPhases = (
+				093AEF8FEE094AECB5EDCED2 /* Check Pods Manifest.lock */,
+				ECF01ECF18C92B7F009E0AD1 /* Sources */,
+				ECF01ED018C92B7F009E0AD1 /* Frameworks */,
+				ECF01ED118C92B7F009E0AD1 /* Resources */,
+				394D14BF947A476EB827103B /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ECF01EE118C92B80009E0AD1 /* PBXTargetDependency */,
+			);
+			name = "pop-tests";
+			productName = "pop-tests";
+			productReference = ECF01ED318C92B7F009E0AD1 /* pop-tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		EC19120F162FB53A00E0CC76 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastTestingUpgradeCheck = 0510;
+				LastUpgradeCheck = 0510;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					0B6BE74719FFD3B900762101 = {
+						CreatedOnToolsVersion = 6.1;
+					};
+					EC7E319818C93D6500B38170 = {
+						TestTargetID = EC68857E18C7B60000C6194C;
+					};
+					ECF01ED218C92B7F009E0AD1 = {
+						TestTargetID = EC191217162FB53A00E0CC76;
+					};
+				};
+			};
+			buildConfigurationList = EC191212162FB53A00E0CC76 /* Build configuration list for PBXProject "pop" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = EC19120D162FB53A00E0CC76;
+			productRefGroup = EC191219162FB53A00E0CC76 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EC191217162FB53A00E0CC76 /* pop */,
+				EC68857E18C7B60000C6194C /* pop-osx */,
+				0B6BE74719FFD3B900762101 /* pop-embedded */,
+				ECF01ED218C92B7F009E0AD1 /* pop-tests */,
+				EC7E319818C93D6500B38170 /* pop-tests-osx */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0B6BE74619FFD3B900762101 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				669428F61A009B6A00A420B0 /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC68857D18C7B60000C6194C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC68858B18C7B60000C6194C /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC7E319718C93D6500B38170 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC7E31A018C93D6500B38170 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECF01ED118C92B7F009E0AD1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		063BFBF07EAD4D74B19E2BC0 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-pop-tests-osx/Pods-pop-tests-osx-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		093AEF8FEE094AECB5EDCED2 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		2F7E04AE9A5B41869AF78DA9 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		394D14BF947A476EB827103B /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-pop-tests/Pods-pop-tests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0B6BE74319FFD3B900762101 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B6BE7D119FFD92700762101 /* POPAnimation.mm in Sources */,
+				0B6BE7D219FFD92700762101 /* POPPropertyAnimation.mm in Sources */,
+				0B6BE7D319FFD92700762101 /* POPBasicAnimation.mm in Sources */,
+				0B6BE7D419FFD92700762101 /* POPCustomAnimation.mm in Sources */,
+				0B6BE7D519FFD92700762101 /* POPDecayAnimation.mm in Sources */,
+				0B6BE7D619FFD92700762101 /* POPSpringAnimation.mm in Sources */,
+				0B6BE7D719FFD92700762101 /* POPAnimatableProperty.mm in Sources */,
+				0B6BE7D819FFD92700762101 /* POPAnimationEvent.mm in Sources */,
+				0B6BE7D919FFD92700762101 /* POPAnimationExtras.mm in Sources */,
+				0B6BE7DA19FFD92700762101 /* POPAnimationRuntime.mm in Sources */,
+				0B6BE7DB19FFD92700762101 /* POPAnimationTracer.mm in Sources */,
+				0B6BE7DC19FFD92700762101 /* POPAnimator.mm in Sources */,
+				0B6BE7DD19FFD92700762101 /* POPCGUtils.mm in Sources */,
+				0B6BE7DE19FFD92700762101 /* POPGeometry.mm in Sources */,
+				0B6BE7DF19FFD92700762101 /* POPLayerExtras.mm in Sources */,
+				0B6BE7E019FFD92800762101 /* POPMath.mm in Sources */,
+				0B6BE7E119FFD92800762101 /* POPVector.mm in Sources */,
+				0B6BE7D019FFD90F00762101 /* TransformationMatrix.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC191214162FB53A00E0CC76 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC191291162FB5B700E0CC76 /* POPAnimation.mm in Sources */,
+				EC6465D11794B4660014176F /* POPMath.mm in Sources */,
+				EC8F014B18FFBC8200DF8905 /* POPPropertyAnimation.mm in Sources */,
+				EC8F016A18FFBEB500DF8905 /* POPSpringAnimation.mm in Sources */,
+				EC191292162FB5B700E0CC76 /* POPAnimator.mm in Sources */,
+				EC94B07917D95447003CE2C8 /* TransformationMatrix.cpp in Sources */,
+				EC70AC4418CCF4FC0067018C /* POPVector.mm in Sources */,
+				EC191293162FB5B700E0CC76 /* POPAnimatableProperty.mm in Sources */,
+				EC0AE13216BC73CE001DA2CE /* POPAnimationExtras.mm in Sources */,
+				EC9553911743E278001E6AF2 /* POPAnimationRuntime.mm in Sources */,
+				EC94B07E17D95CAA003CE2C8 /* POPLayerExtras.mm in Sources */,
+				EC35DB2B18EE3E820023E077 /* POPAnimationTracer.mm in Sources */,
+				5E17BB2117457345009842B6 /* POPCustomAnimation.mm in Sources */,
+				EC67007418D3D89F00F7387F /* POPCGUtils.mm in Sources */,
+				ECD80F1318CFD2EF00AE4303 /* POPGeometry.mm in Sources */,
+				EC8F015E18FFBE8C00DF8905 /* POPDecayAnimation.mm in Sources */,
+				EC9997561756A0C300A73F49 /* POPAnimationEvent.mm in Sources */,
+				EC8F015118FFBD3E00DF8905 /* POPBasicAnimation.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC68857A18C7B60000C6194C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC6885C318C7BD4E00C6194C /* POPAnimator.mm in Sources */,
+				EC6885B618C7BD2200C6194C /* POPAnimationEvent.mm in Sources */,
+				EC8F014C18FFBC8200DF8905 /* POPPropertyAnimation.mm in Sources */,
+				EC8F016B18FFBEB500DF8905 /* POPSpringAnimation.mm in Sources */,
+				EC6885BE18C7BD4000C6194C /* POPAnimationRuntime.mm in Sources */,
+				EC6885B418C7BD1A00C6194C /* POPAnimation.mm in Sources */,
+				EC70AC4518CCF4FC0067018C /* POPVector.mm in Sources */,
+				EC6885BC18C7BD3A00C6194C /* POPMath.mm in Sources */,
+				EC6885D218C7BD8900C6194C /* TransformationMatrix.cpp in Sources */,
+				EC6885B118C7BD1000C6194C /* POPAnimatableProperty.mm in Sources */,
+				EC6885C618C7BD5900C6194C /* POPCustomAnimation.mm in Sources */,
+				EC35DB2C18EE3E820023E077 /* POPAnimationTracer.mm in Sources */,
+				EC67007518D3D89F00F7387F /* POPCGUtils.mm in Sources */,
+				ECD80F1418CFD2EF00AE4303 /* POPGeometry.mm in Sources */,
+				EC6885C918C7BD6300C6194C /* POPLayerExtras.mm in Sources */,
+				EC8F015F18FFBE8C00DF8905 /* POPDecayAnimation.mm in Sources */,
+				EC6885B918C7BD3000C6194C /* POPAnimationExtras.mm in Sources */,
+				EC8F015218FFBD3E00DF8905 /* POPBasicAnimation.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC7E319518C93D6500B38170 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC72875618E13348006EEE54 /* POPCustomAnimationTests.mm in Sources */,
+				EC7E31AB18C9419000B38170 /* POPAnimatable.mm in Sources */,
+				EC7E31AD18C9419600B38170 /* POPAnimationTests.mm in Sources */,
+				EC6C098A19141BBD00F8EA96 /* POPBasicAnimationTests.mm in Sources */,
+				EC7E31B318C941A700B38170 /* POPEaseInEaseOutAnimationTests.mm in Sources */,
+				EC7E31AE18C9419900B38170 /* POPAnimationMRRTests.mm in Sources */,
+				EC7E31AC18C9419200B38170 /* POPBaseAnimationTests.mm in Sources */,
+				EC67007718D3D96600F7387F /* POPCGUtils.mm in Sources */,
+				EC7E31B118C941A200B38170 /* POPDecayAnimationTests.mm in Sources */,
+				EC7E31B018C9419F00B38170 /* POPAnimatablePropertyTests.mm in Sources */,
+				EC7E31AF18C9419C00B38170 /* POPAnimationTestsExtras.mm in Sources */,
+				EC7E31B218C941A400B38170 /* POPSpringAnimationTests.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECF01ECF18C92B7F009E0AD1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC72875518E13348006EEE54 /* POPCustomAnimationTests.mm in Sources */,
+				ECDA0CC618C92BC900D14897 /* POPAnimatable.mm in Sources */,
+				ECDA0CC818C92BD200D14897 /* POPAnimationTests.mm in Sources */,
+				EC6C098919141BBD00F8EA96 /* POPBasicAnimationTests.mm in Sources */,
+				ECDA0CCE18C92BD200D14897 /* POPEaseInEaseOutAnimationTests.mm in Sources */,
+				ECDA0CC918C92BD200D14897 /* POPAnimationMRRTests.mm in Sources */,
+				ECDA0CC718C92BD200D14897 /* POPBaseAnimationTests.mm in Sources */,
+				EC67007618D3D96500F7387F /* POPCGUtils.mm in Sources */,
+				ECDA0CCC18C92BD200D14897 /* POPDecayAnimationTests.mm in Sources */,
+				ECDA0CCB18C92BD200D14897 /* POPAnimatablePropertyTests.mm in Sources */,
+				ECDA0CCA18C92BD200D14897 /* POPAnimationTestsExtras.mm in Sources */,
+				ECDA0CCD18C92BD200D14897 /* POPSpringAnimationTests.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		EC7E31A518C93D6600B38170 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EC68857E18C7B60000C6194C /* pop-osx */;
+			targetProxy = EC7E31A418C93D6600B38170 /* PBXContainerItemProxy */;
+		};
+		ECF01EE118C92B80009E0AD1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EC191217162FB53A00E0CC76 /* pop */;
+			targetProxy = ECF01EE018C92B80009E0AD1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		EC68858918C7B60000C6194C /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EC68858A18C7B60000C6194C /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		EC7E319E18C93D6500B38170 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EC7E319F18C93D6500B38170 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		EC882A7818C91983007829CC /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EC882A7918C91983007829CC /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		0B6BE75C19FFD3B900762101 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0BA2A8F219FFDC7F00B28783 /* DynamicLibrary-iOS.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = "";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		0B6BE75D19FFD3B900762101 /* GCOV */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0BA2A8F219FFDC7F00B28783 /* DynamicLibrary-iOS.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = GCOV;
+		};
+		0B6BE75E19FFD3B900762101 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0BA2A8F219FFDC7F00B28783 /* DynamicLibrary-iOS.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		0B6BE75F19FFD3B900762101 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0BA2A8F219FFDC7F00B28783 /* DynamicLibrary-iOS.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Profile;
+		};
+		9062CE2A16BC56CC00655F1D /* GCOV */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1318CA291B008C7DEA /* Project-GCOV.xcconfig */;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+			};
+			name = GCOV;
+		};
+		9062CE2B16BC56CC00655F1D /* GCOV */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
+			buildSettings = {
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
+			};
+			name = GCOV;
+		};
+		A2BDDD3D185A687F00838797 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1618CA291B008C7DEA /* Project-Profile.xcconfig */;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+			};
+			name = Profile;
+		};
+		A2BDDD3E185A687F00838797 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
+			buildSettings = {
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
+			};
+			name = Profile;
+		};
+		EC19123B162FB53A00E0CC76 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1218CA291B008C7DEA /* Project-Debug.xcconfig */;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				ONLY_ACTIVE_ARCH = YES;
+			};
+			name = Debug;
+		};
+		EC19123C162FB53A00E0CC76 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1718CA291B008C7DEA /* Project-Release.xcconfig */;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+			};
+			name = Release;
+		};
+		EC19123E162FB53A00E0CC76 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
+			buildSettings = {
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
+			};
+			name = Debug;
+		};
+		EC19123F162FB53A00E0CC76 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1A18CA291B008C7DEA /* StaticLibrary-iOS.xcconfig */;
+			buildSettings = {
+				GCC_PREFIX_HEADER = "pop/pop-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+				PUBLIC_HEADERS_FOLDER_PATH = ../Headers/POP;
+			};
+			name = Release;
+		};
+		EC6885A418C7B60100C6194C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1B18CA291B008C7DEA /* StaticLibrary-OSX.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+			};
+			name = Debug;
+		};
+		EC6885A518C7B60100C6194C /* GCOV */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1B18CA291B008C7DEA /* StaticLibrary-OSX.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+			};
+			name = GCOV;
+		};
+		EC6885A618C7B60100C6194C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1B18CA291B008C7DEA /* StaticLibrary-OSX.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+			};
+			name = Release;
+		};
+		EC6885A718C7B60100C6194C /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ECC1DB1B18CA291B008C7DEA /* StaticLibrary-OSX.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_PREFIX_HEADER = "$(PRODUCT_NAME)/$(PRODUCT_NAME)-Prefix.pch";
+				INFOPLIST_FILE = "pop/pop-Info.plist";
+				PRODUCT_NAME = pop;
+			};
+			name = Profile;
+		};
+		EC7E31A718C93D6600B38170 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9BBD2916A451976950B4C1F6 /* Pods-pop-tests-osx.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests-osx/pop-tests-OSX-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "pop-tests-osx/pop-tests-OSX-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "pop-tests-osx";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		EC7E31A818C93D6600B38170 /* GCOV */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7628E8427F4090DD496F92B1 /* Pods-pop-tests-osx.gcov.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests-osx/pop-tests-OSX-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "pop-tests-osx/pop-tests-OSX-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "pop-tests-osx";
+				SDKROOT = macosx;
+			};
+			name = GCOV;
+		};
+		EC7E31A918C93D6600B38170 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7BDD7D9C2D2C9AC55E295CD0 /* Pods-pop-tests-osx.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests-osx/pop-tests-OSX-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "pop-tests-osx/pop-tests-OSX-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "pop-tests-osx";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		EC7E31AA18C93D6600B38170 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7D469990AA7D05FB882F89FC /* Pods-pop-tests-osx.profile.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests-osx/pop-tests-OSX-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "pop-tests-osx/pop-tests-OSX-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "pop-tests-osx";
+				SDKROOT = macosx;
+			};
+			name = Profile;
+		};
+		ECF01EE318C92B80009E0AD1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F4245BFB89B6239FE145E69 /* Pods-pop-tests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests/pop-tests-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "pop-tests";
+			};
+			name = Debug;
+		};
+		ECF01EE418C92B80009E0AD1 /* GCOV */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 408E6FF86BDD3F47FC44BF6A /* Pods-pop-tests.gcov.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests/pop-tests-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_NAME = "pop-tests";
+			};
+			name = GCOV;
+		};
+		ECF01EE518C92B80009E0AD1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C5794B0CC3DBDE8D02CF112A /* Pods-pop-tests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests/pop-tests-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_NAME = "pop-tests";
+			};
+			name = Release;
+		};
+		ECF01EE618C92B80009E0AD1 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3606F0C22CF0EB387E8AC270 /* Pods-pop-tests.profile.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "pop-tests/pop-tests-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_NAME = "pop-tests";
+			};
+			name = Profile;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0B6BE75B19FFD3B900762101 /* Build configuration list for PBXNativeTarget "pop-embedded" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0B6BE75C19FFD3B900762101 /* Debug */,
+				0B6BE75D19FFD3B900762101 /* GCOV */,
+				0B6BE75E19FFD3B900762101 /* Release */,
+				0B6BE75F19FFD3B900762101 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EC191212162FB53A00E0CC76 /* Build configuration list for PBXProject "pop" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EC19123B162FB53A00E0CC76 /* Debug */,
+				9062CE2A16BC56CC00655F1D /* GCOV */,
+				EC19123C162FB53A00E0CC76 /* Release */,
+				A2BDDD3D185A687F00838797 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EC19123D162FB53A00E0CC76 /* Build configuration list for PBXNativeTarget "pop" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EC19123E162FB53A00E0CC76 /* Debug */,
+				9062CE2B16BC56CC00655F1D /* GCOV */,
+				EC19123F162FB53A00E0CC76 /* Release */,
+				A2BDDD3E185A687F00838797 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EC6885A318C7B60100C6194C /* Build configuration list for PBXNativeTarget "pop-osx" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EC6885A418C7B60100C6194C /* Debug */,
+				EC6885A518C7B60100C6194C /* GCOV */,
+				EC6885A618C7B60100C6194C /* Release */,
+				EC6885A718C7B60100C6194C /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EC7E31A618C93D6600B38170 /* Build configuration list for PBXNativeTarget "pop-tests-osx" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EC7E31A718C93D6600B38170 /* Debug */,
+				EC7E31A818C93D6600B38170 /* GCOV */,
+				EC7E31A918C93D6600B38170 /* Release */,
+				EC7E31AA18C93D6600B38170 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ECF01EE218C92B80009E0AD1 /* Build configuration list for PBXNativeTarget "pop-tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ECF01EE318C92B80009E0AD1 /* Debug */,
+				ECF01EE418C92B80009E0AD1 /* GCOV */,
+				ECF01EE518C92B80009E0AD1 /* Release */,
+				ECF01EE618C92B80009E0AD1 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = EC19120F162FB53A00E0CC76 /* Project object */;
+}

--- a/pop.xcodeproj/xcshareddata/xcschemes/pop-osx.xcscheme
+++ b/pop.xcodeproj/xcshareddata/xcschemes/pop-osx.xcscheme
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "EC7E319818C93D6500B38170"
-               BuildableName = "pop-tests-osx.octest"
+               BuildableName = "pop-tests-osx.xctest"
                BlueprintName = "pop-tests-osx"
                ReferencedContainer = "container:pop.xcodeproj">
             </BuildableReference>
@@ -49,6 +49,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EC68857E18C7B60000C6194C"
+            BuildableName = "pop.framework"
+            BlueprintName = "pop-osx"
+            ReferencedContainer = "container:pop.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/pop.xcodeproj/xcshareddata/xcschemes/pop.xcscheme
+++ b/pop.xcodeproj/xcshareddata/xcschemes/pop.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "ECF01ED218C92B7F009E0AD1"
-               BuildableName = "pop-tests.octest"
+               BuildableName = "pop-tests.xctest"
                BlueprintName = "pop-tests"
                ReferencedContainer = "container:pop.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "ECF01ED218C92B7F009E0AD1"
-               BuildableName = "pop-tests.octest"
+               BuildableName = "pop-tests.xctest"
                BlueprintName = "pop-tests"
                ReferencedContainer = "container:pop.xcodeproj">
             </BuildableReference>
@@ -61,7 +61,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "ECF01ED218C92B7F009E0AD1"
-               BuildableName = "pop-tests.octest"
+               BuildableName = "pop-tests.xctest"
                BlueprintName = "pop-tests"
                ReferencedContainer = "container:pop.xcodeproj">
             </BuildableReference>
@@ -77,6 +77,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EC191217162FB53A00E0CC76"
+            BuildableName = "libpop.a"
+            BlueprintName = "pop"
+            ReferencedContainer = "container:pop.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
"What it says on the tin."

Needed to add some magic to the Podfile to ensure that XCTest was properly integrated. OCMock does provide its own xcconfigs, however these don't have a dependence on XCTest.