### PR TITLE
Simulate display link with timer if display link creation failed.

### DIFF
--- a/pop/POPAnimationTracer.mm
+++ b/pop/POPAnimationTracer.mm
@@ -32,18 +32,19 @@ static POPAnimationEvent *create_event(POPAnimationTracer *self, POPAnimationEve
     : self->_animationState->lastTime;
 
   POPAnimationEvent *event;
+  __strong POPAnimation* animation = self->_animation;
 
   if (!value) {
     event = [[POPAnimationEvent alloc] initWithType:type time:time];
   } else {
     event = [[POPAnimationValueEvent alloc] initWithType:type time:time value:value];
     if (self->_animationHasVelocity) {
-      [(POPAnimationValueEvent *)event setVelocity:[(POPSpringAnimation *)self->_animation velocity]];
+      [(POPAnimationValueEvent *)event setVelocity:[(POPSpringAnimation *)animation velocity]];
     }
   }
 
   if (recordAnimation) {
-    event.animationDescription = [self->_animation description];
+    event.animationDescription = [animation description];
   }
 
   return event;

--- a/pop/POPAnimator.h
+++ b/pop/POPAnimator.h
@@ -27,6 +27,11 @@
  */
 @property (weak, nonatomic) id<POPAnimatorDelegate> delegate;
 
+/**
+ Retrieves the nominal refresh period of a display link. Returns zero if unavailable.
+ */
+@property (readonly, nonatomic) CFTimeInterval refreshPeriod;
+
 @end
 
 /**

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -389,7 +389,9 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
     CVDisplayLinkSetOutputCallback(_displayLink, displayLinkCallback, (__bridge void *)self);
   } else {
     FBLogAnimInfo(@"cannot create display link: ret=%ld, falling back to display timer at %llu Hz", (long)ret, _displayTimerFrequency);
-    _displayTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0));
+    // Thanks to Apple, on older OSes DISPATCH_TIMER_STRICT is not supported and dispatch_source_create failed if we use it.
+    unsigned long mask = (NSFoundationVersionNumber >= NSFoundationVersionNumber10_9) ? DISPATCH_TIMER_STRICT : 0;
+    _displayTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, mask, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0));
     NSAssert(nil != _displayTimer, @"Cannot create display timer");
     dispatch_source_set_timer(_displayTimer, DISPATCH_TIME_NOW, NSEC_PER_SEC / _displayTimerFrequency, 0);
     __weak POPAnimator *weakSelf = self;

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -749,7 +749,7 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
   OSSpinLockLock(&_lock);
 
   // get keys
-  NSArray *keys = [(__bridge NSDictionary*)CFDictionaryGetValue(_dict, (__bridge void *)obj) allKeys];
+  NSArray *keys = [(__bridge NSDictionary *)CFDictionaryGetValue(_dict, (__bridge void *)obj) allKeys];
 
   // unlock
   OSSpinLockUnlock(&_lock);
@@ -777,8 +777,9 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
 #else
   if (NULL != self->_displayLink) {
     CVTime period = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(self->_displayLink);
-    if (period.flags & kCVTimeIsIndefinite)
+    if (period.flags & kCVTimeIsIndefinite) {
       return 0;
+    }
     return ((CFTimeInterval)period.timeValue / (CFTimeInterval)period.timeScale);
   }
   return (1.0 / (CFTimeInterval)kDisplayTimerFrequency);

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -746,7 +746,7 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
   OSSpinLockLock(&_lock);
 
   // get keys
-  NSArray *keys = [(__bridge id)CFDictionaryGetValue(_dict, (__bridge void *)obj) allKeys];
+  NSArray *keys = [(__bridge NSDictionary*)CFDictionaryGetValue(_dict, (__bridge void *)obj) allKeys];
 
   // unlock
   OSSpinLockUnlock(&_lock);

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -404,7 +404,10 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
   }
   if (_displayTimer != NULL) {
     dispatch_source_cancel(_displayTimer);
+#if !OS_OBJECT_USE_OBJC
     dispatch_release(_displayTimer);
+#endif
+    _displayTimer = NULL;
   }
 #endif
   [self _clearPendingListObserver];

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -767,6 +767,21 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
   return animation;
 }
 
+- (CFTimeInterval)refreshPeriod
+{
+#if TARGET_OS_IPHONE
+  return self->_displayLink.duration;
+#else
+  if (NULL != self->_displayLink) {
+    CVTime period = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(self->_displayLink);
+    if (period.flags & kCVTimeIsIndefinite)
+      return 0;
+    return ((CFTimeInterval)period.timeValue / (CFTimeInterval)period.timeScale);
+  }
+  return (1.0 / (CFTimeInterval)kDisplayTimerFrequency);
+#endif
+}
+
 - (CFTimeInterval)_currentRenderTime
 {
   CFTimeInterval time = CACurrentMediaTime();

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -44,7 +44,7 @@ using namespace POP;
 #endif
 
 #if !TARGET_OS_IPHONE
-static const uint64_t kDisplayTimerFrequency = 50ull; // Hz
+static const uint64_t kDisplayTimerFrequency = 60ull; // Hz
 #endif
 
 class POPAnimatorItem

--- a/pop/POPAnimatorPrivate.h
+++ b/pop/POPAnimatorPrivate.h
@@ -29,6 +29,12 @@
  */
 + (BOOL)disableBackgroundThread;
 + (void)setDisableBackgroundThread:(BOOL)flag;
+
+/**
+ Determines the frequency (Hz) of the timer used when no display is available. Defaults to 60Hz.
+ */
++ (uint64_t)displayTimerFrequency;
++ (void)setDisplayTimerFrequency:(uint64_t)frequency;
 #endif
 
 /**


### PR DESCRIPTION
Typically if no display is attached, the creation of display link will failed miserably.
Since I use POP to animate custom properties that are not related to visual effects (sound volume ramps), I need to simulate a VBL.