### PR TITLE
Allows animations to be paused *now*

### DIFF
--- a/pop/POPAnimationInternal.h
+++ b/pop/POPAnimationInternal.h
@@ -247,7 +247,7 @@ struct _POPAnimationState
   progress(0),
   repeatCount(0),
   active(false),
-  paused(true),
+  paused(false),
   removedOnCompletion(true),
   delegateDidStart(false),
   delegateDidStop(false),
@@ -323,7 +323,7 @@ struct _POPAnimationState
       
       // activate & unpause
       active = true;
-      setPaused(false);
+      //setPaused(false);
       
       // note start time
       startTime = lastTime = time;


### PR DESCRIPTION
Calls to _render will automatically enable pause, this wouldn't be an issue but the call to _render is called at some time in the future (especially if CADisplayLink is not configured).  This patch allows you to use state.paused = true at creation time.  By default, the animation will start in a non-paused state