### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
 xcode_workspace: pop.xcworkspace
 xcode_scheme: pop
 xcode_sdk:
-  - iphonesimulator7.0
-  - iphonesimulator7.1
+  - iphonesimulator
+  - iphonesimulator8.1


### PR DESCRIPTION
This fixes #227

For some reason Travis CI doesn't have the 7.0 or 7.1 iOS simulator SDKs anymore, so we'll just default to using whatever it does have (8.1)