### PR TITLE
Fix SceneKit Usage in POPCGUtils

### DIFF
--- a/pop/POPCGUtils.h
+++ b/pop/POPCGUtils.h
@@ -15,11 +15,11 @@
 #import <AppKit/AppKit.h>
 #endif
 
+#import "POPDefines.h"
+
 #if SCENEKIT_SDK_AVAILABLE
 #import <SceneKit/SceneKit.h>
 #endif
-
-#import "POPDefines.h"
 
 POP_EXTERN_C_BEGIN
 


### PR DESCRIPTION
The POPDefines header is imported after the SCENEKIT_SDK_AVAILABLE check which contains the actual SCENEKIT_SDK_AVAILABLE definition.