### PR TITLE
Adding support for Bridging Header to use POP in Swift projects correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alternatively, you can add the project to your workspace and adopt the provided 
 Pop adopts the Core Animation explicit animation programming model. Use by including the following import:
 
 ```objective-c
-#import <pop/POP.h>
+#import "pop/POP.h"
 ```
 
 or if you're using the embedded framework:

--- a/pop-embedded/pop-embedded.h
+++ b/pop-embedded/pop-embedded.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <UIKit/UIKit.h>
+#import "UIKit/UIKit.h"
 
 //! Project version number for pop-ios.
 FOUNDATION_EXPORT double pop_iosVersionNumber;
@@ -15,6 +15,6 @@ FOUNDATION_EXPORT double pop_iosVersionNumber;
 //! Project version string for pop-ios.
 FOUNDATION_EXPORT const unsigned char pop_iosVersionString[];
 
-// In this header, you should import all the public headers of your framework using statements like #import <pop_ios/PublicHeader.h>
+// In this header, you should import all the public headers of your framework using statements like #import "pop_ios/PublicHeader.h"
 
 

--- a/pop-tests-osx/pop-tests-OSX-Prefix.pch
+++ b/pop-tests-osx/pop-tests-OSX-Prefix.pch
@@ -5,5 +5,5 @@
 //
 
 #ifdef __OBJC__
-  #import <Cocoa/Cocoa.h>
+  #import "Cocoa/Cocoa.h"
 #endif

--- a/pop-tests/POPAnimatable.h
+++ b/pop-tests/POPAnimatable.h
@@ -7,11 +7,11 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <CoreGraphics/CoreGraphics.h>
+#import "CoreGraphics/CoreGraphics.h"
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
 @interface POPAnimatable : NSObject
 

--- a/pop-tests/POPAnimatable.mm
+++ b/pop-tests/POPAnimatable.mm
@@ -9,7 +9,7 @@
 
 #import "POPAnimatable.h"
 
-#import <pop/POP.h>
+#import "POP.h"
 
 @implementation POPAnimatable
 {

--- a/pop-tests/POPAnimatablePropertyTests.mm
+++ b/pop-tests/POPAnimatablePropertyTests.mm
@@ -7,9 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <pop/POPAnimatableProperty.h>
+#import "POPAnimatableProperty.h"
 
 static const CGFloat epsilon = 0.0001f;
 static NSArray *properties = @[@"name", @"readBlock", @"writeBlock", @"threshold"];

--- a/pop-tests/POPAnimationMRRTests.mm
+++ b/pop-tests/POPAnimationMRRTests.mm
@@ -7,14 +7,14 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
-#import <OCMock/OCMock.h>
+#import "OCMock/OCMock.h"
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <pop/POP.h>
-#import <pop/POPAnimatorPrivate.h>
+#import "POP.h"
+#import "POPAnimatorPrivate.h"
 
 #import "POPAnimationTestsExtras.h"
 

--- a/pop-tests/POPAnimationTests.mm
+++ b/pop-tests/POPAnimationTests.mm
@@ -7,15 +7,15 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
-#import <OCMock/OCMock.h>
+#import "OCMock/OCMock.h"
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <pop/POP.h>
-#import <pop/POPAnimationPrivate.h>
-#import <pop/POPAnimatorPrivate.h>
+#import "POP.h"
+#import "POPAnimationPrivate.h"
+#import "POPAnimatorPrivate.h"
 
 #import "POPAnimatable.h"
 #import "POPAnimationRuntime.h"

--- a/pop-tests/POPAnimationTestsExtras.mm
+++ b/pop-tests/POPAnimationTestsExtras.mm
@@ -9,8 +9,8 @@
 
 #import "POPAnimationTestsExtras.h"
 
-#import <pop/POP.h>
-#import <pop/POPAnimatorPrivate.h>
+#import "POP.h"
+#import "POPAnimatorPrivate.h"
 
 void POPAnimatorRenderTime(POPAnimator *animator, CFTimeInterval beginTime, CFTimeInterval time)
 {

--- a/pop-tests/POPBaseAnimationTests.h
+++ b/pop-tests/POPBaseAnimationTests.h
@@ -7,9 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <cmath>
+#import "cmath>
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
 #import "POPCGUtils.h"
 

--- a/pop-tests/POPBaseAnimationTests.mm
+++ b/pop-tests/POPBaseAnimationTests.mm
@@ -9,12 +9,12 @@
 
 #import "POPBaseAnimationTests.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
-#import <OCMock/OCMock.h>
+#import "OCMock/OCMock.h"
 
-#import <pop/POP.h>
-#import <pop/POPAnimatorPrivate.h>
+#import "POP.h"
+#import "POPAnimatorPrivate.h"
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPBasicAnimationTests.mm
+++ b/pop-tests/POPBasicAnimationTests.mm
@@ -7,10 +7,10 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <OCMock/OCMock.h>
-#import <pop/POPBasicAnimation.h>
+#import "OCMock/OCMock.h"
+#import "POPBasicAnimation.h"
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPCustomAnimationTests.mm
+++ b/pop-tests/POPCustomAnimationTests.mm
@@ -7,11 +7,11 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <OCMock/OCMock.h>
+#import "OCMock/OCMock.h"
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <pop/POPCustomAnimation.h>
+#import "POPCustomAnimation.h"
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPDecayAnimationTests.mm
+++ b/pop-tests/POPDecayAnimationTests.mm
@@ -7,14 +7,14 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
-#import <OCMock/OCMock.h>
+#import "OCMock/OCMock.h"
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <pop/POP.h>
-#import <pop/POPAnimatorPrivate.h>
+#import "POP.h"
+#import "POPAnimatorPrivate.h"
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPEaseInEaseOutAnimationTests.mm
+++ b/pop-tests/POPEaseInEaseOutAnimationTests.mm
@@ -7,14 +7,14 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <OCMock/OCMock.h>
+#import "OCMock/OCMock.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <pop/POP.h>
-#import <pop/POPAnimatorPrivate.h>
+#import "POP.h"
+#import "POPAnimatorPrivate.h"
 
 #import "POPAnimatable.h"
 #import "POPAnimationTestsExtras.h"

--- a/pop-tests/POPSpringAnimationTests.mm
+++ b/pop-tests/POPSpringAnimationTests.mm
@@ -7,17 +7,17 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <OCMock/OCMock.h>
+#import "OCMock/OCMock.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
-#import <XCTest/XCTest.h>
+#import "XCTest/XCTest.h"
 
-#import <pop/POPAnimation.h>
-#import <pop/POPAnimationPrivate.h>
-#import <pop/POPAnimator.h>
-#import <pop/POPAnimatorPrivate.h>
-#import <pop/POPAnimationExtras.h>
+#import "POPAnimation.h"
+#import "POPAnimationPrivate.h"
+#import "POPAnimator.h"
+#import "POPAnimatorPrivate.h"
+#import "POPAnimationExtras.h"
 
 #import "POPAnimatable.h"
 #import "POPAnimationInternal.h"

--- a/pop-tests/pop-tests-Prefix.pch
+++ b/pop-tests/pop-tests-Prefix.pch
@@ -5,6 +5,6 @@
 //
 
 #ifdef __OBJC__
-  #import <UIKit/UIKit.h>
-  #import <Foundation/Foundation.h>
+  #import "UIKit/UIKit.h"
+  #import "Foundation/Foundation.h"
 #endif

--- a/pop/POP.h
+++ b/pop/POP.h
@@ -10,20 +10,20 @@
 #ifndef POP_POP_H
 #define POP_POP_H
 
-#import <pop/POPDefines.h>
+#import "POPDefines.h"
 
-#import <pop/POPAnimatableProperty.h>
-#import <pop/POPAnimation.h>
-#import <pop/POPAnimationEvent.h>
-#import <pop/POPAnimationExtras.h>
-#import <pop/POPAnimationTracer.h>
-#import <pop/POPAnimator.h>
-#import <pop/POPBasicAnimation.h>
-#import <pop/POPCustomAnimation.h>
-#import <pop/POPDecayAnimation.h>
-#import <pop/POPGeometry.h>
-#import <pop/POPLayerExtras.h>
-#import <pop/POPPropertyAnimation.h>
-#import <pop/POPSpringAnimation.h>
+#import "POPAnimatableProperty.h"
+#import "POPAnimation.h"
+#import "POPAnimationEvent.h"
+#import "POPAnimationExtras.h"
+#import "POPAnimationTracer.h"
+#import "POPAnimator.h"
+#import "POPBasicAnimation.h"
+#import "POPCustomAnimation.h"
+#import "POPDecayAnimation.h"
+#import "POPGeometry.h"
+#import "POPLayerExtras.h"
+#import "POPPropertyAnimation.h"
+#import "POPSpringAnimation.h"
 
 #endif /* POP_POP_H */

--- a/pop/POPAction.h
+++ b/pop/POPAction.h
@@ -10,9 +10,9 @@
 #ifndef POPACTION_H
 #define POPACTION_H
 
-#import <QuartzCore/CATransaction.h>
+#import "QuartzCore/CATransaction.h"
 
-#import <pop/POPDefines.h>
+#import "POPDefines.h"
 
 #ifdef __cplusplus
 

--- a/pop/POPAnimatableProperty.h
+++ b/pop/POPAnimatableProperty.h
@@ -7,11 +7,11 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <CoreGraphics/CoreGraphics.h>
+#import "CoreGraphics/CoreGraphics.h"
 
-#import <Foundation/NSObject.h>
+#import "Foundation/NSObject.h"
 
-#import <pop/POPDefines.h>
+#import "POPDefines.h"
 
 @class POPMutableAnimatableProperty;
 

--- a/pop/POPAnimatableProperty.mm
+++ b/pop/POPAnimatableProperty.mm
@@ -9,7 +9,7 @@
 
 #import "POPAnimatableProperty.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
 #import "POPAnimationRuntime.h"
 #import "POPCGUtils.h"

--- a/pop/POPAnimation.h
+++ b/pop/POPAnimation.h
@@ -7,10 +7,10 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/NSObject.h>
+#import "Foundation/NSObject.h"
 
-#import <pop/POPAnimationTracer.h>
-#import <pop/POPGeometry.h>
+#import "POPAnimationTracer.h"
+#import "POPGeometry.h"
 
 @class CAMediaTimingFunction;
 

--- a/pop/POPAnimation.mm
+++ b/pop/POPAnimation.mm
@@ -10,7 +10,7 @@
 #import "POPAnimationExtras.h"
 #import "POPAnimationInternal.h"
 
-#import <objc/runtime.h>
+#import "objc/runtime.h"
 
 #import "POPAction.h"
 #import "POPAnimationRuntime.h"

--- a/pop/POPAnimationEvent.h
+++ b/pop/POPAnimationEvent.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
 /**
  @abstract Enumeraton of animation event types.

--- a/pop/POPAnimationEventInternal.h
+++ b/pop/POPAnimationEventInternal.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
 #import "POPAnimationEvent.h"
 

--- a/pop/POPAnimationExtras.h
+++ b/pop/POPAnimationExtras.h
@@ -7,10 +7,10 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <QuartzCore/CAAnimation.h>
+#import "QuartzCore/CAAnimation.h"
 
-#import <pop/POPDefines.h>
-#import <pop/POPSpringAnimation.h>
+#import "POPDefines.h"
+#import "POPSpringAnimation.h"
 
 /**
  @abstract The current drag coefficient.

--- a/pop/POPAnimationExtras.mm
+++ b/pop/POPAnimationExtras.mm
@@ -11,7 +11,7 @@
 #import "POPAnimationPrivate.h"
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+#import "UIKit/UIKit.h"
 #endif
 
 #if TARGET_IPHONE_SIMULATOR

--- a/pop/POPAnimationInternal.h
+++ b/pop/POPAnimationInternal.h
@@ -9,7 +9,7 @@
 
 #import "POPAnimation.h"
 
-#import <QuartzCore/CAMediaTimingFunction.h>
+#import "QuartzCore/CAMediaTimingFunction.h"
 
 #import "POPAction.h"
 #import "POPAnimationRuntime.h"

--- a/pop/POPAnimationPrivate.h
+++ b/pop/POPAnimationPrivate.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <pop/POPAnimation.h>
+#import "POPAnimation.h"
 
 #define POP_ANIMATION_FRICTION_FOR_QC_FRICTION(qcFriction) (25.0 + (((qcFriction - 8.0) / 2.0) * (25.0 - 19.0)))
 #define POP_ANIMATION_TENSION_FOR_QC_TENSION(qcTension) (194.0 + (((qcTension - 30.0) / 50.0) * (375.0 - 194.0)))

--- a/pop/POPAnimationRuntime.h
+++ b/pop/POPAnimationRuntime.h
@@ -7,9 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <objc/runtime.h>
+#import "objc/runtime.h"
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
 #import "POPVector.h"
 

--- a/pop/POPAnimationRuntime.mm
+++ b/pop/POPAnimationRuntime.mm
@@ -9,12 +9,12 @@
 
 #import "POPAnimationRuntime.h"
 
-#import <objc/objc.h>
+#import "objc/objc.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+#import "UIKit/UIKit.h"
 #endif
 
 #import "POPCGUtils.h"

--- a/pop/POPAnimationTracer.h
+++ b/pop/POPAnimationTracer.h
@@ -7,9 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
-#import <pop/POPAnimationEvent.h>
+#import "POPAnimationEvent.h"
 
 @class POPAnimation;
 

--- a/pop/POPAnimationTracer.mm
+++ b/pop/POPAnimationTracer.mm
@@ -9,7 +9,7 @@
 
 #import "POPAnimationTracer.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
 #import "POPAnimationEventInternal.h"
 #import "POPAnimationInternal.h"

--- a/pop/POPAnimationTracerInternal.h
+++ b/pop/POPAnimationTracerInternal.h
@@ -7,9 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
-#import <pop/POPAnimationTracer.h>
+#import "POPAnimationTracer.h"
 
 @interface POPAnimationTracer (Internal)
 

--- a/pop/POPAnimator.h
+++ b/pop/POPAnimator.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/NSObject.h>
+#import "Foundation/NSObject.h"
 
 @protocol POPAnimatorDelegate;
 

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -10,16 +10,16 @@
 #import "POPAnimator.h"
 #import "POPAnimatorPrivate.h"
 
-#import <list>
-#import <vector>
+#import "list>
+#import "vector>
 
 #if !TARGET_OS_IPHONE
-#import <libkern/OSAtomic.h>
+#import "libkern/OSAtomic.h"
 #endif
 
-#import <objc/objc-auto.h>
+#import "objc/objc-auto.h"
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
 #import "POPAnimation.h"
 #import "POPAnimationExtras.h"

--- a/pop/POPAnimatorPrivate.h
+++ b/pop/POPAnimatorPrivate.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <pop/POPAnimator.h>
+#import "POPAnimator.h"
 
 @class POPAnimation;
 

--- a/pop/POPBasicAnimation.h
+++ b/pop/POPBasicAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <pop/POPPropertyAnimation.h>
+#import "POPPropertyAnimation.h"
 
 /**
  @abstract A concrete basic animation class.

--- a/pop/POPCGUtils.h
+++ b/pop/POPCGUtils.h
@@ -7,18 +7,18 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <CoreGraphics/CoreGraphics.h>
+#import "CoreGraphics/CoreGraphics.h"
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+#import "UIKit/UIKit.h"
 #else
-#import <AppKit/AppKit.h>
+#import "AppKit/AppKit.h"
 #endif
 
 #import "POPDefines.h"
 
 #if SCENEKIT_SDK_AVAILABLE
-#import <SceneKit/SceneKit.h>
+#import "SceneKit/SceneKit.h"
 #endif
 
 POP_EXTERN_C_BEGIN

--- a/pop/POPCustomAnimation.h
+++ b/pop/POPCustomAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <pop/POPAnimation.h>
+#import "POPAnimation.h"
 
 @class POPCustomAnimation;
 

--- a/pop/POPDecayAnimation.h
+++ b/pop/POPDecayAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <pop/POPPropertyAnimation.h>
+#import "POPPropertyAnimation.h"
 
 /**
  @abstract A concrete decay animation class.

--- a/pop/POPDecayAnimation.mm
+++ b/pop/POPDecayAnimation.mm
@@ -10,7 +10,7 @@
 #import "POPDecayAnimationInternal.h"
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+#import "UIKit/UIKit.h"
 #endif
 
 const POPValueType supportedVelocityTypes[6] = { kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, kPOPValueSize, kPOPValueEdgeInsets };

--- a/pop/POPDecayAnimationInternal.h
+++ b/pop/POPDecayAnimationInternal.h
@@ -9,7 +9,7 @@
 
 #import "POPDecayAnimation.h"
 
-#import <cmath>
+#import "cmath>
 
 #import "POPPropertyAnimationInternal.h"
 

--- a/pop/POPDefines.h
+++ b/pop/POPDefines.h
@@ -10,7 +10,7 @@
 #ifndef POP_POPDefines_h
 #define POP_POPDefines_h
 
-#import <Availability.h>
+#import "Availability.h"
 
 #ifdef __cplusplus
 # define POP_EXTERN_C_BEGIN extern "C" {

--- a/pop/POPGeometry.h
+++ b/pop/POPGeometry.h
@@ -7,10 +7,10 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIGeometry.h>
+#import "UIKit/UIGeometry.h"
 #endif
 
 #if !TARGET_OS_IPHONE

--- a/pop/POPGeometry.mm
+++ b/pop/POPGeometry.mm
@@ -70,7 +70,7 @@
 #import "POPDefines.h"
 
 #if SCENEKIT_SDK_AVAILABLE
-#import <SceneKit/SceneKit.h>
+#import "SceneKit/SceneKit.h"
 
 /**
   Dirty hacks because iOS is weird and decided to define both SCNVector3's and SCNVector4's objCType as "t". However @encode(SCNVector3) and @encode(SCNVector4) both return the proper definition ("{SCNVector3=fff}" and "{SCNVector4=ffff}" respectively)

--- a/pop/POPLayerExtras.h
+++ b/pop/POPLayerExtras.h
@@ -7,9 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <QuartzCore/QuartzCore.h>
+#import "QuartzCore/QuartzCore.h"
 
-#import <pop/POPDefines.h>
+#import "POPDefines.h"
 
 POP_EXTERN_C_BEGIN
 

--- a/pop/POPMath.h
+++ b/pop/POPMath.h
@@ -7,9 +7,9 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
-#import <CoreGraphics/CoreGraphics.h>
+#import "CoreGraphics/CoreGraphics.h"
 
 #import "POPDefines.h"
 #import "POPVector.h"

--- a/pop/POPPropertyAnimation.h
+++ b/pop/POPPropertyAnimation.h
@@ -7,8 +7,8 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <pop/POPAnimatableProperty.h>
-#import <pop/POPAnimation.h>
+#import "POPAnimatableProperty.h"
+#import "POPAnimation.h"
 
 /**
  @abstract Flags for clamping animation values.

--- a/pop/POPSpringAnimation.h
+++ b/pop/POPSpringAnimation.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <pop/POPPropertyAnimation.h>
+#import "POPPropertyAnimation.h"
 
 /**
  @abstract A concrete spring animation class.

--- a/pop/POPSpringAnimationInternal.h
+++ b/pop/POPSpringAnimationInternal.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <cmath>
+#import "cmath>
 
 #import "POPAnimationExtras.h"
 #import "POPPropertyAnimationInternal.h"

--- a/pop/POPSpringSolver.h
+++ b/pop/POPSpringSolver.h
@@ -7,7 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
+#import "Foundation/Foundation.h"
 
 #import "POPVector.h"
 

--- a/pop/POPVector.h
+++ b/pop/POPVector.h
@@ -13,18 +13,18 @@
 #include <iostream>
 #include <vector>
 
-#import <objc/NSObjCRuntime.h>
+#import "objc/NSObjCRuntime.h"
 
-#import <CoreGraphics/CoreGraphics.h>
+#import "CoreGraphics/CoreGraphics.h"
 
 #import "POPDefines.h"
 
 #if SCENEKIT_SDK_AVAILABLE
-#import <SceneKit/SceneKit.h>
+#import "SceneKit/SceneKit.h"
 #endif
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+#import "UIKit/UIKit.h"
 #endif
 
 #import "POPMath.h"

--- a/pop/WebCore/FloatConversion.h
+++ b/pop/WebCore/FloatConversion.h
@@ -29,7 +29,7 @@
 #ifndef FloatConversion_h
 #define FloatConversion_h
 
-#include <CoreGraphics/CGBase.h>
+#include <CoreGraphics/CGBase.h"
 
 namespace WebCore {
 

--- a/pop/WebCore/TransformationMatrix.cpp
+++ b/pop/WebCore/TransformationMatrix.cpp
@@ -26,7 +26,7 @@
 
 #include "TransformationMatrix.h"
 
-#include <math.h>
+#include <math.h"
 
 #include "FloatConversion.h"
 

--- a/pop/WebCore/TransformationMatrix.h
+++ b/pop/WebCore/TransformationMatrix.h
@@ -26,11 +26,11 @@
 #ifndef TransformationMatrix_h
 #define TransformationMatrix_h
 
-#include <string.h> //for memcpy
+#include <string.h" //for memcpy
 
-#include <CoreGraphics/CGAffineTransform.h>
+#include <CoreGraphics/CGAffineTransform.h"
 
-#include <QuartzCore/QuartzCore.h>
+#include <QuartzCore/QuartzCore.h"
 
 namespace WebCore {
 

--- a/pop/WebCore/UnitBezier.h
+++ b/pop/WebCore/UnitBezier.h
@@ -26,7 +26,7 @@
 #ifndef UnitBezier_h
 #define UnitBezier_h
 
-#include <math.h>
+#include <math.h"
 
 namespace WebCore {
   

--- a/pop/pop-Prefix.pch
+++ b/pop/pop-Prefix.pch
@@ -3,5 +3,5 @@
 //
 
 #ifdef __OBJC__
-  #import <Foundation/Foundation.h>
+  #import "Foundation/Foundation.h"
 #endif


### PR DESCRIPTION
It was just change on references like #import &lt;whatever.h>  to #import "whatever.h"