### PR TITLE
Added helper function -isLayerAnimation to POPPropertyAnimation

### DIFF
--- a/pop/POPPropertyAnimation.h
+++ b/pop/POPPropertyAnimation.h
@@ -62,4 +62,10 @@ typedef NS_OPTIONS(NSUInteger, POPAnimationClampFlags)
  */
 @property (assign, nonatomic, getter = isAdditive) BOOL additive;
 
+/**
+ @abstract Quick method to check whether this animation should be added to a view or layer.
+ @returns YES if this animation should be added to a layer and NO if it should be added to a view or other object.
+ */
+- (BOOL)isLayerAnimation;
+
 @end

--- a/pop/POPPropertyAnimation.mm
+++ b/pop/POPPropertyAnimation.mm
@@ -82,7 +82,6 @@ DEFINE_RW_PROPERTY_OBJ_COPY(POPPropertyAnimationState, progressMarkers, setProgr
 
 - (BOOL)isLayerAnimation
 {
-  
   // This is a small hack - since layer animations take place on properties in the layer itself,
   // there shouldn't be dot notation to access the layer's property.
   return ([self.property.name rangeOfString:@"."].location == NSNotFound);

--- a/pop/POPPropertyAnimation.mm
+++ b/pop/POPPropertyAnimation.mm
@@ -80,6 +80,13 @@ DEFINE_RW_PROPERTY_OBJ_COPY(POPPropertyAnimationState, progressMarkers, setProgr
   return POPBox(__state->currentValue(), __state->valueType);
 }
 
+- (BOOL)isLayerAnimation {
+  
+  // This is a small hack - since layer animations take place on properties in the layer itself,
+  // there shouldn't be dot notation to access the layer's property.
+  return ([self.property.name rangeOfString:@"."].location == NSNotFound);
+}
+
 #pragma mark - Utility
 
 - (void)_appendDescription:(NSMutableString *)s debug:(BOOL)debug

--- a/pop/POPPropertyAnimation.mm
+++ b/pop/POPPropertyAnimation.mm
@@ -80,7 +80,8 @@ DEFINE_RW_PROPERTY_OBJ_COPY(POPPropertyAnimationState, progressMarkers, setProgr
   return POPBox(__state->currentValue(), __state->valueType);
 }
 
-- (BOOL)isLayerAnimation {
+- (BOOL)isLayerAnimation
+{
   
   // This is a small hack - since layer animations take place on properties in the layer itself,
   // there shouldn't be dot notation to access the layer's property.


### PR DESCRIPTION
This addition is kind of a hack - since the property names of layer animations don't use dot notation (since they don't need to), you can check the property name for "." to tell if the animation should be applied to a view or its underlying layer in situations where the scope is not responsible for /applying/ the animation, but only /supplying/ it (i.e. [CKComponentPOPAnimation](https://github.com/crylico/CKComponentPOPAnimation/blob/auto-layer/CKComponentPOPAnimation.mm)).

Let me know what you guys think! Or if you can think of a better way to distinguished based solely on the property name.