### PR TITLE
keyPath property animations

### DIFF
--- a/pop.xcodeproj/project.pbxproj
+++ b/pop.xcodeproj/project.pbxproj
@@ -192,6 +192,9 @@
 		ECDA0CD118C92D3900D14897 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECC5A89D162FBD9B00F7F15C /* CoreGraphics.framework */; };
 		ECF01ED518C92B7F009E0AD1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC19121B162FB53A00E0CC76 /* Foundation.framework */; };
 		ECF01ED618C92B7F009E0AD1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECEED93D18C91ACF00DD95F2 /* UIKit.framework */; };
+		FA9A1C9F1BAA408E0050046A /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9A1C9E1BAA408E0050046A /* GLKit.framework */; };
+		FA9A1CA01BAA40940050046A /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9A1C9E1BAA408E0050046A /* GLKit.framework */; };
+		FA9A1CA21BAA409A0050046A /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9A1CA11BAA409A0050046A /* GLKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -330,6 +333,8 @@
 		ECD80F1018CFD2EF00AE4303 /* POPGeometry.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = POPGeometry.mm; sourceTree = "<group>"; };
 		ECEED93D18C91ACF00DD95F2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		ECF01ED318C92B7F009E0AD1 /* pop-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "pop-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA9A1C9E1BAA408E0050046A /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		FA9A1CA11BAA409A0050046A /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/GLKit.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -337,6 +342,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA9A1CA01BAA40940050046A /* GLKit.framework in Frameworks */,
 				1818937C1B3B77BB002C4A59 /* CoreImage.framework in Frameworks */,
 				1818937B1B3B77B7002C4A59 /* UIKit.framework in Frameworks */,
 				181893741B3B776B002C4A59 /* CoreFoundation.framework in Frameworks */,
@@ -350,6 +356,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA9A1C9F1BAA408E0050046A /* GLKit.framework in Frameworks */,
 				1818937A1B3B77B2002C4A59 /* CoreImage.framework in Frameworks */,
 				181893791B3B7785002C4A59 /* CoreGraphics.framework in Frameworks */,
 				181893771B3B7781002C4A59 /* CoreFoundation.framework in Frameworks */,
@@ -363,6 +370,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA9A1CA21BAA409A0050046A /* GLKit.framework in Frameworks */,
 				1836BBE41B3B7B9C0041334F /* Cocoa.framework in Frameworks */,
 				EC6885D418C7C44E00C6194C /* QuartzCore.framework in Frameworks */,
 			);
@@ -443,6 +451,8 @@
 		EC19121A162FB53A00E0CC76 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FA9A1CA11BAA409A0050046A /* GLKit.framework */,
+				FA9A1C9E1BAA408E0050046A /* GLKit.framework */,
 				1836BBE31B3B7B9C0041334F /* Cocoa.framework */,
 				181893731B3B776B002C4A59 /* CoreFoundation.framework */,
 				0B6BE7E619FFD98100762101 /* CoreImage.framework */,
@@ -872,7 +882,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0700;
-				LastUpgradeCheck = 0640;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					0B6BE74719FFD3B900762101 = {

--- a/pop.xcodeproj/project.pbxproj
+++ b/pop.xcodeproj/project.pbxproj
@@ -195,6 +195,9 @@
 		FA9A1C9F1BAA408E0050046A /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9A1C9E1BAA408E0050046A /* GLKit.framework */; };
 		FA9A1CA01BAA40940050046A /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9A1C9E1BAA408E0050046A /* GLKit.framework */; };
 		FA9A1CA21BAA409A0050046A /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9A1CA11BAA409A0050046A /* GLKit.framework */; };
+		FA9A1CAB1BAA51F00050046A /* POPAnimatablePropertyInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FA9A1CA91BAA51F00050046A /* POPAnimatablePropertyInternal.h */; settings = {ASSET_TAGS = (); }; };
+		FA9A1CAC1BAA51F00050046A /* POPAnimatablePropertyInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FA9A1CA91BAA51F00050046A /* POPAnimatablePropertyInternal.h */; settings = {ASSET_TAGS = (); }; };
+		FA9A1CAD1BAA51F00050046A /* POPAnimatablePropertyInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FA9A1CA91BAA51F00050046A /* POPAnimatablePropertyInternal.h */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -335,6 +338,7 @@
 		ECF01ED318C92B7F009E0AD1 /* pop-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "pop-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA9A1C9E1BAA408E0050046A /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		FA9A1CA11BAA409A0050046A /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/GLKit.framework; sourceTree = DEVELOPER_DIR; };
+		FA9A1CA91BAA51F00050046A /* POPAnimatablePropertyInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPAnimatablePropertyInternal.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -587,6 +591,7 @@
 		EC8F017318FFC4CB00DF8905 /* Engine */ = {
 			isa = PBXGroup;
 			children = (
+				FA9A1CA91BAA51F00050046A /* POPAnimatablePropertyInternal.h */,
 				EC19128E162FB5B700E0CC76 /* POPAnimatableProperty.h */,
 				EC19128F162FB5B700E0CC76 /* POPAnimatableProperty.mm */,
 				EC9997531756A0C300A73F49 /* POPAnimationEvent.h */,
@@ -688,6 +693,7 @@
 				0B6BE77119FFD46F00762101 /* POPAnimatorPrivate.h in Headers */,
 				0B6BE77019FFD46600762101 /* POPLayerExtras.h in Headers */,
 				0B6BE76F19FFD44000762101 /* POPSpringAnimation.h in Headers */,
+				FA9A1CAC1BAA51F00050046A /* POPAnimatablePropertyInternal.h in Headers */,
 				0B6BE76E19FFD43800762101 /* POPCustomAnimation.h in Headers */,
 				0B6BE76D19FFD42700762101 /* POPAnimationExtras.h in Headers */,
 				0B6BE76C19FFD41D00762101 /* POPDecayAnimation.h in Headers */,
@@ -710,6 +716,7 @@
 				EC191299162FB5EC00E0CC76 /* POPAnimatableProperty.h in Headers */,
 				EC8F014F18FFBD3E00DF8905 /* POPBasicAnimation.h in Headers */,
 				EC8F014018FFBBD300DF8905 /* POPPropertyAnimation.h in Headers */,
+				FA9A1CAB1BAA51F00050046A /* POPAnimatablePropertyInternal.h in Headers */,
 				EC191296162FB5EC00E0CC76 /* POPAnimationInternal.h in Headers */,
 				EC191298162FB5EC00E0CC76 /* POPAnimatorPrivate.h in Headers */,
 				ECCBC57217D96DBD00C69976 /* FloatConversion.h in Headers */,
@@ -750,6 +757,7 @@
 				EC6885C818C7BD5F00C6194C /* POPLayerExtras.h in Headers */,
 				EC8F015018FFBD3E00DF8905 /* POPBasicAnimation.h in Headers */,
 				EC8F014118FFBBD300DF8905 /* POPPropertyAnimation.h in Headers */,
+				FA9A1CAD1BAA51F00050046A /* POPAnimatablePropertyInternal.h in Headers */,
 				EC6885BB18C7BD3700C6194C /* POPMath.h in Headers */,
 				EC6885C418C7BD5100C6194C /* POPAnimatorPrivate.h in Headers */,
 				EC6885C518C7BD5500C6194C /* POPCustomAnimation.h in Headers */,

--- a/pop.xcodeproj/xcshareddata/xcschemes/pop-ios-framework.xcscheme
+++ b/pop.xcodeproj/xcshareddata/xcschemes/pop-ios-framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,15 +48,18 @@
             ReferencedContainer = "container:pop.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -71,10 +74,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/pop.xcodeproj/xcshareddata/xcschemes/pop-ios-static.xcscheme
+++ b/pop.xcodeproj/xcshareddata/xcschemes/pop-ios-static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:pop.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/pop.xcodeproj/xcshareddata/xcschemes/pop-osx-framework.xcscheme
+++ b/pop.xcodeproj/xcshareddata/xcschemes/pop-osx-framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,15 +39,18 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -62,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/pop/POPAnimatableProperty.mm
+++ b/pop/POPAnimatableProperty.mm
@@ -15,6 +15,8 @@
 #import "POPCGUtils.h"
 #import "POPDefines.h"
 #import "POPLayerExtras.h"
+#import "POPGeometry.h"
+#import "POPAnimatablePropertyInternal.h"
 
 // common threshold definitions
 static CGFloat const kPOPThresholdColor = 0.01;
@@ -1239,6 +1241,144 @@ static POPAnimatableProperty *placeholder = nil;
 + (id)propertyWithName:(NSString *)aName
 {
   return [self propertyWithName:aName initializer:NULL];
+}
+
++ (id)propertyWithName:(NSString*)name keyPath:(NSString*)keyPath valueType:(POPValueType)valueType
+{
+  return [self propertyWithName:name initializer:^(POPMutableAnimatableProperty *prop) {
+    
+    void(^readBlock)(id obj, CGFloat values[]) = NULL;
+    void(^writeBlock)(id obj, const CGFloat values[]) = NULL;
+    CGFloat threshold = 0.01;
+    
+    switch (valueType)
+    {
+      case kPOPValueInteger:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          id res = [obj valueForKeyPath:keyPath];
+          values[0] = [res integerValue];
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          NSInteger val = values[0];
+          [obj setValue:@(val) forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      case kPOPValueFloat:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          id res = [obj valueForKeyPath:keyPath];
+          values[0] = [res floatValue];
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          CGFloat val = values[0];
+          [obj setValue:@(val) forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      case kPOPValuePoint:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          CGPoint pt = [[obj valueForKeyPath:keyPath] CGPointValue];
+          values[0] = pt.x;
+          values[1] = pt.y;
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          CGPoint pt = CGPointMake( values[0], values[1] );
+          [obj setValue:[NSValue valueWithCGPoint:pt] forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      case kPOPValueSize:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          CGSize size = [[obj valueForKeyPath:keyPath] CGSizeValue];
+          values[0] = size.width;
+          values[1] = size.height;
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          CGSize size = CGSizeMake( values[0], values[1] );
+          [obj setValue:[NSValue valueWithCGSize:size] forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      case kPOPValueRect:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          CGRect rect = [[obj valueForKeyPath:keyPath] CGRectValue];
+          values[0] = rect.origin.x;
+          values[1] = rect.origin.y;
+          values[2] = rect.size.width;
+          values[3] = rect.size.height;
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          CGRect rect = CGRectMake(values[0], values[1], values[2], values[3]);
+          [obj setValue:[NSValue valueWithCGRect:rect] forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      case kPOPValueEdgeInsets:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          UIEdgeInsets ei = [[obj valueForKeyPath:keyPath] UIEdgeInsetsValue];
+          values[0] = ei.top;
+          values[1] = ei.left;
+          values[2] = ei.bottom;
+          values[3] = ei.right;
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          UIEdgeInsets ei = UIEdgeInsetsMake(values[0], values[1], values[2], values[3]);
+          [obj setValue:[NSValue valueWithUIEdgeInsets:ei] forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      case kPOPValueGLKVector3:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          GLKVector3 v = [[obj valueForKeyPath:keyPath] GLKVector3Value];
+          values[0] = v.v[0];
+          values[1] = v.v[1];
+          values[2] = v.v[2];
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          GLKVector3 v = GLKVector3Make(values[0], values[1], values[2] );
+          [obj setValue:[NSValue valueWithGLKVector3:v] forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      case kPOPValueGLKQuaternion:
+      {
+        readBlock = ^(id obj, CGFloat values[]) {
+          GLKQuaternion q = [[obj valueForKeyPath:keyPath] GLKQuaternionValue];
+          values[0] = q.q[0];
+          values[1] = q.q[1];
+          values[2] = q.q[2];
+          values[3] = q.q[3];
+        };
+        writeBlock = ^(id obj, const CGFloat values[]) {
+          GLKQuaternion q = GLKQuaternionMake(values[0], values[1], values[2], values[3]);
+          [obj setValue:[NSValue valueWithGLKQuaternion:q] forKeyPath:keyPath];
+        };
+      }
+        break;
+        
+      default:
+        break;
+    }
+    
+    prop.readBlock = readBlock;
+    prop.writeBlock = writeBlock;
+    prop.threshold = threshold;
+    
+  }];
 }
 
 + (id)propertyWithName:(NSString *)aName initializer:(void (^)(POPMutableAnimatableProperty *prop))aBlock

--- a/pop/POPAnimatablePropertyInternal.h
+++ b/pop/POPAnimatablePropertyInternal.h
@@ -16,7 +16,7 @@
  @param keyPath The keyPath of the property.
  @param valueType The type of objC value of the property.
  @return The animatable property for that keyPath or nil if it can't be created.
- @discussion Common animatable properties are included by default. Use the provided constants to reference.
+ @discussion Used by animations created with keyPaths.
  */
 + (id)propertyWithName:(NSString*)name keyPath:(NSString*)keyPath valueType:(POPValueType)valueType;
 

--- a/pop/POPAnimatablePropertyInternal.h
+++ b/pop/POPAnimatablePropertyInternal.h
@@ -1,0 +1,23 @@
+//
+//  POPAnimatablePropertyInternal.h
+//  pop
+//
+//  Created by Alexander Cohen on 2015-09-16.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import "POPAnimatableProperty.h"
+
+@interface POPAnimatableProperty ()
+
+/**
+ @abstract Property accessor.
+ @param name The name of the property.
+ @param keyPath The keyPath of the property.
+ @param valueType The type of objC value of the property.
+ @return The animatable property for that keyPath or nil if it can't be created.
+ @discussion Common animatable properties are included by default. Use the provided constants to reference.
+ */
++ (id)propertyWithName:(NSString*)name keyPath:(NSString*)keyPath valueType:(POPValueType)valueType;
+
+@end

--- a/pop/POPAnimationRuntime.h
+++ b/pop/POPAnimationRuntime.h
@@ -28,6 +28,8 @@ enum POPValueType
   kPOPValueColor,
   kPOPValueSCNVector3,
   kPOPValueSCNVector4,
+  kPOPValueGLKVector3,
+  kPOPValueGLKQuaternion
 };
 
 using namespace POP;
@@ -45,12 +47,12 @@ extern POPValueType POPSelectValueType(id obj, const POPValueType *types, size_t
 /**
  Array of all value types.
  */
-extern const POPValueType kPOPAnimatableAllTypes[12];
+extern const POPValueType kPOPAnimatableAllTypes[14];
 
 /**
  Array of all value types supported for animation.
  */
-extern const POPValueType kPOPAnimatableSupportTypes[10];
+extern const POPValueType kPOPAnimatableSupportTypes[12];
 
 /**
  Returns a string description of a value type.

--- a/pop/POPAnimationRuntime.mm
+++ b/pop/POPAnimationRuntime.mm
@@ -12,6 +12,7 @@
 #import <objc/objc.h>
 
 #import <QuartzCore/QuartzCore.h>
+#import <GLKit/GLKit.h>
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -136,6 +137,12 @@ static bool FBCompareTypeEncoding(const char *objctype, POPValueType type)
 #else
       return false;
 #endif
+    
+    case kPOPValueGLKVector3:
+      return (strcmp(objctype, @encode(GLKVector3)) == 0);
+      
+    case kPOPValueGLKQuaternion:
+      return (strcmp(objctype, @encode(GLKQuaternion)) == 0);
       
     default:
       return false;
@@ -163,9 +170,9 @@ POPValueType POPSelectValueType(id obj, const POPValueType *types, size_t length
   return kPOPValueUnknown;
 }
 
-const POPValueType kPOPAnimatableAllTypes[12] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueEdgeInsets, kPOPValueAffineTransform, kPOPValueTransform, kPOPValueRange, kPOPValueColor, kPOPValueSCNVector3, kPOPValueSCNVector4};
+const POPValueType kPOPAnimatableAllTypes[14] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueEdgeInsets, kPOPValueAffineTransform, kPOPValueTransform, kPOPValueRange, kPOPValueColor, kPOPValueSCNVector3, kPOPValueSCNVector4, kPOPValueGLKVector3, kPOPValueGLKQuaternion};
 
-const POPValueType kPOPAnimatableSupportTypes[10] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueEdgeInsets, kPOPValueColor, kPOPValueSCNVector3, kPOPValueSCNVector4};
+const POPValueType kPOPAnimatableSupportTypes[12] = {kPOPValueInteger, kPOPValueFloat, kPOPValuePoint, kPOPValueSize, kPOPValueRect, kPOPValueEdgeInsets, kPOPValueColor, kPOPValueSCNVector3, kPOPValueSCNVector4, kPOPValueGLKVector3, kPOPValueGLKQuaternion};
 
 NSString *POPValueTypeToString(POPValueType t)
 {
@@ -196,6 +203,10 @@ NSString *POPValueTypeToString(POPValueType t)
       return @"SCNVector3";
     case kPOPValueSCNVector4:
       return @"SCNVector4";
+    case kPOPValueGLKVector3:
+      return @"GLKVector3";
+    case kPOPValueGLKQuaternion:
+      return @"GLKQuaternion";
     default:
       return nil;
   }
@@ -239,6 +250,15 @@ id POPBox(VectorConstRef vec, POPValueType type, bool force)
       break;
     }
 #endif
+    case kPOPValueGLKVector3: {
+      return [NSValue valueWithGLKVector3:vec->glk_vector3()];
+      break;
+    }
+      
+    case kPOPValueGLKQuaternion: {
+      return [NSValue valueWithGLKQuaternion:vec->glk_quaternion()];
+      break;
+    }
     default:
       return force ? [NSValue valueWithCGPoint:vec->cg_point()] : nil;
       break;
@@ -286,6 +306,13 @@ static VectorRef vectorize(id value, POPValueType type)
       vec = Vector::new_scn_vector4([value SCNVector4Value]);
       break;
 #endif
+    case kPOPValueGLKVector3:
+      vec = Vector::new_glk_vector3([value GLKVector3Value]);
+      break;
+      
+    case kPOPValueGLKQuaternion:
+      vec = Vector::new_glk_quaternion([value GLKQuaternionValue]);
+      break;
     default:
       break;
   }

--- a/pop/POPAnimator.mm
+++ b/pop/POPAnimator.mm
@@ -25,6 +25,7 @@
 #import "POPAnimationExtras.h"
 #import "POPBasicAnimationInternal.h"
 #import "POPDecayAnimation.h"
+#import "POPAnimatablePropertyInternal.h"
 
 using namespace std;
 using namespace POP;
@@ -562,7 +563,41 @@ static void stopAndCleanup(POPAnimator *self, POPAnimatorItemRef item, bool shou
   if (!key) {
     key = [[NSUUID UUID] UUIDString];
   }
-
+  
+  // support for default property
+  if ( [anim isKindOfClass:[POPPropertyAnimation class]] ) {
+    POPPropertyAnimation* propAnim = (POPPropertyAnimation*)anim;
+    if ( propAnim.keyPath.length ) {
+      
+      // support animationPropertyFor<keyPath>
+      NSMutableString *propertyName = [NSMutableString string];
+      NSArray *parts = [propAnim.keyPath componentsSeparatedByString:@"."];
+      for ( NSString* part in parts )
+      {
+        NSString* partValue = [part stringByReplacingCharactersInRange:NSMakeRange(0,1) withString:[[part substringToIndex:1] capitalizedString]];
+        [propertyName appendString:partValue];
+      }
+      
+      NSString *methodName = [@"animationPropertyFor" stringByAppendingString:propertyName];
+      SEL selector = NSSelectorFromString(methodName);
+      if ( [obj respondsToSelector:selector] )
+      {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        propAnim.property = [obj performSelector:selector];
+#pragma clang diagnostic pop
+      }
+      
+      // support for automatic properties
+      if ( !propAnim.property )
+      {
+        id  val = [obj valueForKeyPath:propAnim.keyPath];
+        POPValueType  valueType = POPSelectValueType( val, kPOPAnimatableSupportTypes, POP_ARRAY_COUNT(kPOPAnimatableSupportTypes) );
+        propAnim.property = [POPAnimatableProperty propertyWithName:[NSString stringWithFormat:@"%p:%@", obj, propAnim.keyPath] keyPath:propAnim.keyPath valueType:valueType];
+      }
+    }
+  }
+  
   // lock
   OSSpinLockLock(&_lock);
 

--- a/pop/POPBasicAnimation.h
+++ b/pop/POPBasicAnimation.h
@@ -29,6 +29,13 @@
 + (instancetype)animationWithPropertyNamed:(NSString *)name;
 
 /**
+ @abstract Convenience initializer that returns an animation with animatable property for the keyPath.
+ @param keyPath The keyPath of the animatable property.
+ @returns An instance of a basic animation configured with specified animatable property for the keyPath.
+ */
++ (instancetype)animationWithKeyPath:(NSString*)keyPath;
+
+/**
  @abstract Convenience constructor.
  @returns Returns a basic animation with kCAMediaTimingFunctionDefault timing function.
  */

--- a/pop/POPBasicAnimation.mm
+++ b/pop/POPBasicAnimation.mm
@@ -28,6 +28,13 @@
   return anim;
 }
 
++ (instancetype)animationWithKeyPath:(NSString*)keyPath
+{
+  POPBasicAnimation *anim = [self animation];
+  anim.keyPath = keyPath;
+  return anim;
+}
+
 - (void)_initState
 {
   _state = new POPBasicAnimationState(self);

--- a/pop/POPBasicAnimationInternal.h
+++ b/pop/POPBasicAnimationInternal.h
@@ -29,6 +29,25 @@ static void interpolate(POPValueType valueType, NSUInteger count, const CGFloat 
     case kPOPValueColor:
       POPInterpolateVector(count, outVec, fromVec, toVec, p);
       break;
+    case kPOPValueGLKVector3: {
+      GLKVector3 from = GLKVector3Make(fromVec[0], fromVec[1], fromVec[2]);
+      GLKVector3 to = GLKVector3Make(toVec[0], toVec[1], toVec[2]);
+      GLKVector3 result = GLKVector3Lerp( from, to, p );
+      outVec[0] = result.v[0];
+      outVec[1] = result.v[1];
+      outVec[2] = result.v[2];
+    }
+      break;
+    case kPOPValueGLKQuaternion: {
+      GLKQuaternion from = GLKQuaternionMake(fromVec[0], fromVec[1], fromVec[2], fromVec[3]);
+      GLKQuaternion to = GLKQuaternionMake(toVec[0], toVec[1], toVec[2], toVec[3]);
+      GLKQuaternion result = GLKQuaternionSlerp( from, to, p );
+      outVec[0] = result.q[0];
+      outVec[1] = result.q[1];
+      outVec[2] = result.q[2];
+      outVec[3] = result.q[3];
+    }
+      break;
     default:
       NSCAssert(false, @"unhandled type %d", valueType);
       break;

--- a/pop/POPCGUtils.h
+++ b/pop/POPCGUtils.h
@@ -15,6 +15,8 @@
 #import <AppKit/AppKit.h>
 #endif
 
+#import <GLKit/GLKit.h>
+
 #import "POPDefines.h"
 
 #if SCENEKIT_SDK_AVAILABLE
@@ -49,6 +51,16 @@ NS_INLINE SCNVector4 values_to_vec4(const CGFloat values[])
   return SCNVector4Make(values[0], values[1], values[2], values[3]);
 }
 #endif
+
+NS_INLINE GLKVector3 values_to_glkvec3(const CGFloat values[])
+{
+  return GLKVector3Make(values[0], values[1], values[2]);
+}
+
+NS_INLINE GLKQuaternion values_to_glkquternion(const CGFloat values[])
+{
+  return GLKQuaternionMake(values[0], values[1], values[2], values[3]);
+}
 
 #if TARGET_OS_IPHONE
 
@@ -95,6 +107,21 @@ NS_INLINE void values_from_vec4(CGFloat values[], SCNVector4 v)
   values[3] = v.w;
 }
 #endif
+
+NS_INLINE void values_from_glkvec3(CGFloat values[], GLKVector3 v)
+{
+  values[0] = v.v[0];
+  values[1] = v.v[1];
+  values[2] = v.v[2];
+}
+
+NS_INLINE void values_from_glkquaternion(CGFloat values[], GLKQuaternion v)
+{
+  values[0] = v.q[0];
+  values[1] = v.q[1];
+  values[2] = v.q[2];
+  values[3] = v.q[3];
+}
 
 #if TARGET_OS_IPHONE
 

--- a/pop/POPDecayAnimation.h
+++ b/pop/POPDecayAnimation.h
@@ -29,6 +29,13 @@
 + (instancetype)animationWithPropertyNamed:(NSString *)name;
 
 /**
+ @abstract Convenience initializer that returns an animation with animatable property for the keyPath.
+ @param keyPath The keyPath of the animatable property.
+ @returns An instance of a decay animation configured with specified animatable property for the keyPath.
+ */
++ (instancetype)animationWithKeyPath:(NSString*)keyPath;
+
+/**
  @abstract The current velocity value.
  @discussion Set before animation start to account for initial velocity. Expressed in change of value units per second. The only POPValueTypes supported for velocity are: kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, kPOPValueSize and kPOPValueGLKVector3.
  */

--- a/pop/POPDecayAnimation.h
+++ b/pop/POPDecayAnimation.h
@@ -30,7 +30,7 @@
 
 /**
  @abstract The current velocity value.
- @discussion Set before animation start to account for initial velocity. Expressed in change of value units per second. The only POPValueTypes supported for velocity are: kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, and kPOPValueSize.
+ @discussion Set before animation start to account for initial velocity. Expressed in change of value units per second. The only POPValueTypes supported for velocity are: kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, kPOPValueSize and kPOPValueGLKVector3.
  */
 @property (copy, nonatomic) id velocity;
 

--- a/pop/POPDecayAnimation.mm
+++ b/pop/POPDecayAnimation.mm
@@ -34,6 +34,13 @@ const POPValueType supportedVelocityTypes[7] = { kPOPValuePoint, kPOPValueIntege
   return anim;
 }
 
++ (instancetype)animationWithKeyPath:(NSString*)keyPath
+{
+  POPDecayAnimation *anim = [self animation];
+  anim.keyPath = keyPath;
+  return anim;
+}
+
 - (id)init
 {
   return [self _init];

--- a/pop/POPDecayAnimation.mm
+++ b/pop/POPDecayAnimation.mm
@@ -13,7 +13,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-const POPValueType supportedVelocityTypes[6] = { kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, kPOPValueSize, kPOPValueEdgeInsets };
+const POPValueType supportedVelocityTypes[7] = { kPOPValuePoint, kPOPValueInteger, kPOPValueFloat, kPOPValueRect, kPOPValueSize, kPOPValueEdgeInsets, kPOPValueGLKVector3 };
 
 @implementation POPDecayAnimation
 
@@ -109,8 +109,11 @@ DEFINE_RW_PROPERTY(POPDecayAnimationState, deceleration, setDeceleration:, CGFlo
     UIEdgeInsets negativeOriginalVelocityInsets = UIEdgeInsetsMake(-originalVelocityInsets.top, -originalVelocityInsets.left, -originalVelocityInsets.bottom, -originalVelocityInsets.right);
     reversedVelocity = [NSValue valueWithUIEdgeInsets:negativeOriginalVelocityInsets];
 #endif
+  } else if ( velocityType == kPOPValueGLKVector3 ) {
+    GLKVector3 originalVelocityVector3 = [self.originalVelocity GLKVector3Value];
+    GLKVector3 negativeOriginalVelocityVector3 = GLKVector3MultiplyScalar(originalVelocityVector3,-1.0);
+    reversedVelocity = [NSValue valueWithGLKVector3:negativeOriginalVelocityVector3];
   }
-
   return reversedVelocity;
 }
 

--- a/pop/POPGeometry.h
+++ b/pop/POPGeometry.h
@@ -13,6 +13,8 @@
 #import <UIKit/UIGeometry.h>
 #endif
 
+#import <GLKit/GLKit.h>
+
 #if !TARGET_OS_IPHONE
 
 /** NSValue extensions to support animatable types. */
@@ -71,3 +73,28 @@
 @end
 
 #endif
+
+/** NSValue extensions to support animatable types for GLKit. */
+@interface NSValue (POPGLKit)
+
+/**
+ @abstract Creates an NSValue given a GLKVector3.
+ */
++ (NSValue *)valueWithGLKVector3:(GLKVector3)vector;
+
+/**
+ @abstract Creates an NSValue given a GLKQuaternion.
+ */
++ (NSValue *)valueWithGLKQuaternion:(GLKQuaternion)quaternion;
+
+/**
+ @abstract Returns the underlying CFRange value.
+ */
+- (GLKVector3)GLKVector3Value;
+
+/**
+ @abstract Returns the underlying CFRange value.
+ */
+- (GLKQuaternion)GLKQuaternionValue;
+
+@end

--- a/pop/POPGeometry.mm
+++ b/pop/POPGeometry.mm
@@ -66,6 +66,30 @@
 
 #endif
 
+@implementation NSValue (POPGLKit)
+
++ (NSValue *)valueWithGLKVector3:(GLKVector3)vector {
+  return [NSValue valueWithBytes:&vector objCType:@encode(GLKVector3)];
+}
+
++ (NSValue *)valueWithGLKQuaternion:(GLKQuaternion)quaternion {
+  return [NSValue valueWithBytes:&quaternion objCType:@encode(GLKQuaternion)];
+}
+
+- (GLKVector3)GLKVector3Value {
+  GLKVector3 result;
+  [self getValue:&result];
+  return result;
+}
+
+- (GLKQuaternion)GLKQuaternionValue {
+  GLKQuaternion result;
+  [self getValue:&result];
+  return result;
+}
+
+@end
+
 #if TARGET_OS_IPHONE
 #import "POPDefines.h"
 

--- a/pop/POPPropertyAnimation.h
+++ b/pop/POPPropertyAnimation.h
@@ -33,6 +33,11 @@ typedef NS_OPTIONS(NSUInteger, POPAnimationClampFlags)
 @property (strong, nonatomic) POPAnimatableProperty *property;
 
 /**
+ @abstract The keyPath to animate.
+ */
+@property (copy, nonatomic, readonly) NSString *keyPath;
+
+/**
  @abstract The value to animate from.
  @discussion The value type should match the property. If unspecified, the value is initialized to the object's current value on animation start.
  */

--- a/pop/POPPropertyAnimation.h
+++ b/pop/POPPropertyAnimation.h
@@ -34,6 +34,7 @@ typedef NS_OPTIONS(NSUInteger, POPAnimationClampFlags)
 
 /**
  @abstract The keyPath to animate.
+ @discussion Once added to an object, property will automagically be filled based on the keyPath. Objects that use this animation must respond to setValue:forKeyPath: and valueForKeyPath: in order for the magic to work. If your object has a method named animationPropertyFor<keyPath> which returns a POPAnimatableProperty, then that method will be called to fill in .property.
  */
 @property (copy, nonatomic, readonly) NSString *keyPath;
 

--- a/pop/POPPropertyAnimation.mm
+++ b/pop/POPPropertyAnimation.mm
@@ -11,6 +11,8 @@
 
 @implementation POPPropertyAnimation
 
+@synthesize keyPath;
+
 #pragma mark - Lifecycle
 
 #undef __state
@@ -117,6 +119,7 @@ DEFINE_RW_PROPERTY_OBJ_COPY(POPPropertyAnimationState, progressMarkers, setProgr
     copy.roundingFactor = self.roundingFactor;
     copy.clampMode = self.clampMode;
     copy.additive = self.additive;
+    copy.keyPath = [self.keyPath copyWithZone:zone];
   }
   
   return copy;

--- a/pop/POPPropertyAnimationInternal.h
+++ b/pop/POPPropertyAnimationInternal.h
@@ -354,6 +354,6 @@ struct _POPPropertyAnimationState : _POPAnimationState
 typedef struct _POPPropertyAnimationState POPPropertyAnimationState;
 
 @interface POPPropertyAnimation ()
-
+@property (copy, nonatomic) NSString *keyPath;
 @end
 

--- a/pop/POPSpringAnimation.h
+++ b/pop/POPSpringAnimation.h
@@ -29,6 +29,13 @@
 + (instancetype)animationWithPropertyNamed:(NSString *)name;
 
 /**
+ @abstract Convenience initializer that returns an animation with animatable property for the keyPath.
+ @param keyPath The keyPath of the animatable property.
+ @returns An instance of a spring animation configured with specified animatable property for the keyPath.
+ */
++ (instancetype)animationWithKeyPath:(NSString*)keyPath;
+
+/**
  @abstract The current velocity value.
  @discussion Set before animation start to account for initial velocity. Expressed in change of value units per second.
  */

--- a/pop/POPSpringAnimation.mm
+++ b/pop/POPSpringAnimation.mm
@@ -28,6 +28,13 @@
   return anim;
 }
 
++ (instancetype)animationWithKeyPath:(NSString*)keyPath
+{
+  POPSpringAnimation *anim = [self animation];
+  anim.keyPath = keyPath;
+  return anim;
+}
+
 - (void)_initState
 {
   _state = new POPSpringAnimationState(self);

--- a/pop/POPVector.h
+++ b/pop/POPVector.h
@@ -16,6 +16,7 @@
 #import <objc/NSObjCRuntime.h>
 
 #import <CoreGraphics/CoreGraphics.h>
+#import <GLKit/GLKit.h>
 
 #import "POPDefines.h"
 
@@ -356,6 +357,14 @@ namespace POP {
     static Vector *new_scn_vector4(const SCNVector4 &vec4);
 #endif
 
+    // GLKVector3 support
+    GLKVector3 glk_vector3() const;
+    static Vector *new_glk_vector3(const GLKVector3 &v);
+    
+    // GLKQuaternion support
+    GLKQuaternion glk_quaternion() const;
+    static Vector *new_glk_quaternion(const GLKQuaternion &q);
+    
     // operator overloads
     CGFloat &operator[](size_t i) const {
       NSCAssert(size() > i, @"unexpected vector size:%lu", (unsigned long)size());

--- a/pop/POPVector.mm
+++ b/pop/POPVector.mm
@@ -283,7 +283,37 @@ namespace POP
     return v;
   }
 #endif
-
+  
+  GLKVector3 Vector::glk_vector3() const
+  {
+    return _count < 3 ? GLKVector3Make(0.0,0.0,0.0) : GLKVector3Make(_values[0], _values[1], _values[2]);
+  }
+  
+  Vector * Vector::new_glk_vector3(const GLKVector3 &p)
+  {
+    Vector *v = new Vector(3);
+    v->_values[0] = p.v[0];
+    v->_values[1] = p.v[1];
+    v->_values[2] = p.v[2];
+    return v;
+  }
+  
+  // GLKQuaternion support
+  GLKQuaternion Vector::glk_quaternion() const
+  {
+    return _count < 4 ? GLKQuaternionMake(0.0, 0.0, 0.0, 0.0) : GLKQuaternionMake(_values[0], _values[1], _values[2], _values[3]);
+  }
+  
+  Vector * Vector::new_glk_quaternion(const GLKQuaternion &p)
+  {
+    Vector *v = new Vector(4);
+    v->_values[0] = p.q[0];
+    v->_values[1] = p.q[1];
+    v->_values[2] = p.q[2];
+    v->_values[3] = p.q[3];
+    return v;
+  }
+  
   void Vector::subRound(CGFloat sub)
   {
     for (NSUInteger idx = 0; idx < _count; idx++) {


### PR DESCRIPTION
##### Added keyPath to POPPropertyAnimation

This enables POPPropertyAnimation.property to be automatically filled in by the engine instead of having to enter it yourself.

```
POPPropertyAnimation *anim = [POPPropertyAnimation animationForKeyPath:@"contentOffset"];
// ... setup your animation
[table pop_addAnimation:anim forKey:@"someKey"];
```

That code will have the engine first check the object it was added to for a method named animationPropertyForContentOffset. If found, it will be called to fill in the property. If not, the engine will then call [object valueForKeyPath:keyPath] in order to figure out what kind of value should be passed around. Then it sets up the property for that that type of value.

##### Slipped in GLKit data type support

2 new types were added, GLKVector3 and GLKQuaternion. GLKVector3 can be used everywhere and GLKQuaternion can be used everywhere except for velocities.

