### PR TITLE
Added tvos to podspec

### DIFF
--- a/pop.podspec
+++ b/pop.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |spec|
   }
   spec.ios.deployment_target = '6.0'
   spec.osx.deployment_target = '10.7'
+  spec.tvos.deployment_target = '9.0'
 end


### PR DESCRIPTION
This makes it possible to use facebook pop on Apple TV 4 apps. Should maybe merged to a different branch since the Apple TV is not released yet. But it should also not break anything if it would be in master ;)