### PR TITLE
Adding support for autolayout constraint multipliers

### DIFF
--- a/pop-tests/POPAnimatablePropertyTests.mm
+++ b/pop-tests/POPAnimatablePropertyTests.mm
@@ -55,6 +55,8 @@ static void assertPropertyEqual(id self, POPAnimatableProperty *prop1, POPAnimat
                      kPOPShapeLayerStrokeColor,
                      kPOPShapeLayerLineWidth,
                      kPOPShapeLayerLineDashPhase,
+                     kPOPLayoutConstraintConstant,
+                     kPOPLayoutConstraintMultiplier,
 #if TARGET_OS_IPHONE
                      kPOPViewAlpha,
                      kPOPViewBackgroundColor,

--- a/pop/POPAnimatableProperty.h
+++ b/pop/POPAnimatableProperty.h
@@ -135,6 +135,7 @@ extern NSString * const kPOPShapeLayerLineDashPhase;
  Common NSLayoutConstraint property names.
  */
 extern NSString * const kPOPLayoutConstraintConstant;
+extern NSString * const kPOPLayoutConstraintMultiplier;
 
 
 #if TARGET_OS_IPHONE

--- a/pop/POPAnimatableProperty.mm
+++ b/pop/POPAnimatableProperty.mm
@@ -68,6 +68,7 @@ NSString * const kPOPShapeLayerLineDashPhase = @"shapeLayer.lineDashPhase";
 
 // NSLayoutConstraint
 NSString * const kPOPLayoutConstraintConstant = @"layoutConstraint.constant";
+NSString * const kPOPLayoutConstraintMultiplier = @"layoutConstraint.multiplier";
 
 #if TARGET_OS_IPHONE
 
@@ -568,7 +569,25 @@ static POPStaticAnimatablePropertyState _staticStates[] =
     },
     0.01
   },
-
+  
+  {kPOPLayoutConstraintMultiplier,
+    ^(NSLayoutConstraint *obj, CGFloat values[]) {
+      values[0] = obj.multiplier;
+    },
+    ^(NSLayoutConstraint *obj, const CGFloat values[]) {
+//  The multiplier property is read-only so recreate the constraint with all existing attributes
+//  besides the desired multiplier.
+      obj = [NSLayoutConstraint constraintWithItem:obj.firstItem
+                                         attribute:obj.firstAttribute
+                                         relatedBy:obj.relation
+                                            toItem:obj.secondItem
+                                         attribute:obj.secondAttribute
+                                        multiplier:values[0]
+                                          constant:obj.constant];
+    },
+    0.01
+  },
+  
 #if TARGET_OS_IPHONE
 
   /* UIView */


### PR DESCRIPTION
I've accommodated the readonly multiplier property the best way I could think of here. Also added the constraint constant property to the unit tests as it was missing.