### PR TITLE
Fix OS X framework install path

### DIFF
--- a/pop.xcodeproj/project.pbxproj
+++ b/pop.xcodeproj/project.pbxproj
@@ -1851,8 +1851,9 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = "$(SRCROOT)/pop/pop-osx-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
+				INSTALL_PATH = "@rpath";
 				PRODUCT_NAME = pop;
+				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
 			};
 			name = Debug;
 		};
@@ -1864,8 +1865,9 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = "$(SRCROOT)/pop/pop-osx-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
+				INSTALL_PATH = "@rpath";
 				PRODUCT_NAME = pop;
+				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
 			};
 			name = Release;
 		};
@@ -1877,8 +1879,9 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = "$(SRCROOT)/pop/pop-osx-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
+				INSTALL_PATH = "@rpath";
 				PRODUCT_NAME = pop;
+				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
 			};
 			name = Profile;
 		};

--- a/pop.xcodeproj/project.pbxproj
+++ b/pop.xcodeproj/project.pbxproj
@@ -1851,6 +1851,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = "$(SRCROOT)/pop/pop-osx-Info.plist";
+				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_NAME = pop;
 			};
 			name = Debug;
@@ -1863,6 +1864,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = "$(SRCROOT)/pop/pop-osx-Info.plist";
+				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_NAME = pop;
 			};
 			name = Release;
@@ -1875,6 +1877,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = "$(SRCROOT)/pop/pop-osx-Info.plist";
+				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_NAME = pop;
 			};
 			name = Profile;


### PR DESCRIPTION
Previously, the value of the build setting `INSTALL_PATH` is `$(SYMROOT)/Headers` which may prevent the dynamic linking from working correctly.

Usually, a dynamic linked OS X framework is copied to `APP_BUNDLE/Contents/Frameworks`, while the executable is usually located at `APP_BUNDLE/Content/MacOS/EXECUTABLE_NAME`. As per [apple document](https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPFrameworks/Tasks/CreatingFrameworks.html), the suggested install path of an OS X framework is `@executable_path/../Frameworks`. 

This pull request changes the build setting `INSTALL_PATH` for target `pop-osx-framework` to `@executable_path/../Frameworks`.