### PR TITLE
Don't use non-standard nested #defines

### DIFF
--- a/pop/POPDefines.h
+++ b/pop/POPDefines.h
@@ -28,10 +28,10 @@
 # define POP_NOTHROW
 #endif
 
-#if TARGET_OS_MAC
-  #define SCENEKIT_SDK_AVAILABLE defined(POP_USE_SCENEKIT)
-#elif TARGET_OS_IPHONE
-  #define SCENEKIT_SDK_AVAILABLE defined(POP_USE_SCENEKIT)
+#if defined(POP_USE_SCENEKIT)
+# if TARGET_OS_MAC || TARGET_OS_IPHONE
+#  define SCENEKIT_SDK_AVAILABLE 1
+# endif
 #endif
 
 #endif


### PR DESCRIPTION
Recent clang builds issue a warning on `#define FOO defined(BAR)`, and if the user specified `-Werror` then this is a hard error. GCC only issues a diagnostic for this with `-pedantic`, but clang is getting more aggressive about reporting this.