### PR TITLE
Fix method documentation typo

### DIFF
--- a/pop/POPAnimation.h
+++ b/pop/POPAnimation.h
@@ -163,7 +163,7 @@ When combined with the autoreverses property, a singular animation is effectivel
 
 /**
  @abstract Returns an array containing the keys of all animations currently attached to the receiver.
- @param The order of keys reflects the order in which animations will be applied.
+ The order of keys reflects the order in which animations will be applied.
  */
 - (NSArray *)pop_animationKeys;
 


### PR DESCRIPTION
The missed @param directive has been removed from `- (NSArray *)pop_animationKeys;`