### PR TITLE
Make externs more correct

### DIFF
--- a/pop/POPAnimatableProperty.h
+++ b/pop/POPAnimatableProperty.h
@@ -88,6 +88,8 @@
 
 @end
 
+POP_EXTERN_C_BEGIN
+
 /**
  Common CALayer property names.
  */
@@ -250,3 +252,5 @@ extern NSString * const kPOPSCNNodeScaleZ;
 extern NSString * const kPOPSCNNodeScaleXY;
 
 #endif
+
+POP_EXTERN_C_END


### PR DESCRIPTION
This is a reapplication of #385, but now rebased on top of latest master.

POP has nontrivial C++. Global symbols should have proper linkage declared. This is easy enough - just wrap it in `extern "C" { ... }`.