### PR TITLE
Update function declaration to latest iOS SDK conventions.

### DIFF
--- a/pop/POPAnimationExtras.h
+++ b/pop/POPAnimationExtras.h
@@ -16,7 +16,7 @@
  @abstract The current drag coefficient.
  @discussion A value greater than 1.0 indicates Simulator slow-motion animations are enabled. Defaults to 1.0.
  */
-extern CGFloat POPAnimationDragCoefficient();
+extern CGFloat POPAnimationDragCoefficient(void);
 
 @interface CAAnimation (POPAnimationExtras)
 


### PR DESCRIPTION
According to latest iOS SDK updates, void parameters in function declarations should be included `void`.