### PR TITLE
Restore Carthage compatbility

### DIFF
--- a/pop/POP.h
+++ b/pop/POP.h
@@ -26,5 +26,6 @@
 #import <pop/POPLayerExtras.h>
 #import <pop/POPPropertyAnimation.h>
 #import <pop/POPSpringAnimation.h>
+#import <pop/POPVector.h>
 
 #endif /* POP_POP_H */


### PR DESCRIPTION
Using pop with Carthage 0.31.2 results in a build-time issue where it tells you that the umbrella header  doesn't include `POPVector.h`. The change included in this commit seems to resolve that issue.